### PR TITLE
refactor: centralize bearer token in BackendApiService

### DIFF
--- a/Preview/PreviewRegistry.cs
+++ b/Preview/PreviewRegistry.cs
@@ -101,7 +101,6 @@ public static class PreviewRegistry
             {
                 var stub = new StubBackendApiService();
                 var vm = new ChatViewModel(stub, new StubHttpImageService(), new StubEmoticonService(), new StubQueueSocketService());
-                vm.GetBackendToken = () => "stub-token";
                 _ = vm.StartAsync();
                 var host = new Avalonia.Controls.Panel
                 {

--- a/Preview/PreviewStubs.cs
+++ b/Preview/PreviewStubs.cs
@@ -41,7 +41,9 @@ internal sealed class StubQueueSocketService : IQueueSocketService
 
 internal sealed class StubBackendApiService : IBackendApiService
 {
-    public Task<PartySnapshot> GetMyPartySnapshotAsync(string bearerToken, CancellationToken cancellationToken = default)
+    public void SetBearerToken(string? token) { }
+
+    public Task<PartySnapshot> GetMyPartySnapshotAsync(CancellationToken cancellationToken = default)
         => Task.FromResult(new PartySnapshot([
             new PartyMemberView("76561198000000001", "Player One", null),
             new PartyMemberView("76561198000000002", "Player Two", null),
@@ -59,13 +61,13 @@ internal sealed class StubBackendApiService : IBackendApiService
     public Task<IReadOnlyList<InviteCandidateView>> SearchPlayersAsync(string name, int count = 25, CancellationToken cancellationToken = default)
         => Task.FromResult<IReadOnlyList<InviteCandidateView>>([]);
 
-    public Task<(string? Name, string? AvatarUrl)?> GetUserInfoAsync(string steamId, string bearerToken, CancellationToken cancellationToken = default)
+    public Task<(string? Name, string? AvatarUrl)?> GetUserInfoAsync(string steamId, CancellationToken cancellationToken = default)
         => Task.FromResult<(string?, string?)?>(null);
 
     public Task<(int InGame, int OnSite)> GetOnlineStatsAsync(CancellationToken cancellationToken = default)
         => Task.FromResult((0, 0));
 
-    public Task<IReadOnlyList<ChatMessageData>> GetChatMessagesAsync(string threadId, int limit, string bearerToken, CancellationToken cancellationToken = default)
+    public Task<IReadOnlyList<ChatMessageData>> GetChatMessagesAsync(string threadId, int limit, CancellationToken cancellationToken = default)
         => Task.FromResult<IReadOnlyList<ChatMessageData>>([
             new ChatMessageData("1", threadId, "Давай сыграем!", "2025-03-05T20:00:00Z", "111", "MaxiKo", null, false),
             new ChatMessageData("2", threadId, "трамвай потеет)", "2025-03-05T20:00:30Z", "111", "MaxiKo", null, false),
@@ -75,7 +77,7 @@ internal sealed class StubBackendApiService : IBackendApiService
             new ChatMessageData("6", threadId, "играю сносно https://dotaclassic.ru/players/198768255 але", "2025-03-05T20:11:00Z", "222", "лоутаб секьюрити", null, false),
         ]);
 
-    public Task PostChatMessageAsync(string threadId, string content, string bearerToken, CancellationToken cancellationToken = default)
+    public Task PostChatMessageAsync(string threadId, string content, CancellationToken cancellationToken = default)
         => Task.CompletedTask;
 
     public Task<IReadOnlyList<EmoticonData>> GetEmoticonsAsync(CancellationToken cancellationToken = default)
@@ -85,7 +87,7 @@ internal sealed class StubBackendApiService : IBackendApiService
         => Task.FromResult<Models.LiveMatchInfo?>(null);
 
     public async IAsyncEnumerable<ChatMessageData> SubscribeChatAsync(
-        string threadId, string bearerToken,
+        string threadId,
         [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken cancellationToken = default)
     {
         // Stub: yield nothing (preview shows only the initially-loaded messages).

--- a/Services/BackendApiService.cs
+++ b/Services/BackendApiService.cs
@@ -33,16 +33,14 @@ public sealed class BackendApiService : IBackendApiService, IDisposable
         BaseAddress = BaseUri,
         Timeout = System.Threading.Timeout.InfiniteTimeSpan
     };
-    // TODO: Merge into a single HttpClient. Setting DefaultRequestHeaders per-call is not
-    // thread-safe under concurrent requests. Prefer passing the bearer token via a delegating
-    // handler or creating a new HttpRequestMessage per call.
-    // Shared client for authenticated requests. Auth header is set per-call before use.
-    // Thread-safe for our single-user desktop app (only one token in flight at a time).
+    // Shared client for authenticated requests. Bearer token is set once via SetBearerToken()
+    // and reused across all authenticated calls.
     private readonly HttpClient _authHttpClient = new HttpClient
     {
         BaseAddress = BaseUri,
         Timeout = TimeSpan.FromSeconds(10)
     };
+    private string? _currentToken;
     private static readonly IReadOnlyDictionary<int, string> MatchmakingModeLabels = new Dictionary<int, string>
     {
         [0] = "Рейтинговая 5x5",
@@ -61,15 +59,21 @@ public sealed class BackendApiService : IBackendApiService, IDisposable
         [13] = "Турбо"
     };
 
-    public async Task<PartySnapshot> GetMyPartySnapshotAsync(string bearerToken, CancellationToken cancellationToken = default)
+    public void SetBearerToken(string? token)
     {
-        if (string.IsNullOrWhiteSpace(bearerToken))
+        _currentToken = token;
+        _authHttpClient.DefaultRequestHeaders.Authorization = string.IsNullOrWhiteSpace(token)
+            ? null
+            : new AuthenticationHeaderValue("Bearer", token);
+    }
+
+    public async Task<PartySnapshot> GetMyPartySnapshotAsync(CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(_currentToken))
         {
             AppLog.Info("Party fetch skipped: backend token is empty.");
             return new PartySnapshot(Array.Empty<PartyMemberView>(), null);
         }
-
-        _authHttpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", bearerToken);
 
         var api = new DotaclassicApiClient(_authHttpClient);
         var party = await api.PlayerController_myPartyAsync(cancellationToken);
@@ -187,14 +191,13 @@ public sealed class BackendApiService : IBackendApiService, IDisposable
         return result;
     }
 
-    public async Task<(string? Name, string? AvatarUrl)?> GetUserInfoAsync(string steamId, string bearerToken, CancellationToken cancellationToken = default)
+    public async Task<(string? Name, string? AvatarUrl)?> GetUserInfoAsync(string steamId, CancellationToken cancellationToken = default)
     {
-        if (string.IsNullOrWhiteSpace(steamId) || string.IsNullOrWhiteSpace(bearerToken))
+        if (string.IsNullOrWhiteSpace(steamId) || string.IsNullOrWhiteSpace(_currentToken))
             return null;
 
         try
         {
-            _authHttpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", bearerToken);
             var api = new DotaclassicApiClient(_authHttpClient);
             var user = await api.PlayerController_userAsync(steamId, cancellationToken).ConfigureAwait(false);
             if (user == null)
@@ -240,10 +243,8 @@ public sealed class BackendApiService : IBackendApiService, IDisposable
     }
 
     public async Task<IReadOnlyList<ChatMessageData>> GetChatMessagesAsync(
-        string threadId, int limit, string bearerToken, CancellationToken cancellationToken = default)
+        string threadId, int limit, CancellationToken cancellationToken = default)
     {
-        _authHttpClient.DefaultRequestHeaders.Authorization =
-            new AuthenticationHeaderValue("Bearer", bearerToken);
         var api = new DotaclassicApiClient(_authHttpClient);
         var messages = await api.ForumController_getMessagesAsync(
             threadId,
@@ -275,10 +276,8 @@ public sealed class BackendApiService : IBackendApiService, IDisposable
     }
 
     public async Task PostChatMessageAsync(
-        string threadId, string content, string bearerToken, CancellationToken cancellationToken = default)
+        string threadId, string content, CancellationToken cancellationToken = default)
     {
-        _authHttpClient.DefaultRequestHeaders.Authorization =
-            new AuthenticationHeaderValue("Bearer", bearerToken);
         var api = new DotaclassicApiClient(_authHttpClient);
         // The POST body expects the full prefixed threadId (e.g. "forum_<uuid>"),
         // while the GET endpoints use the bare UUID + a separate threadType param.
@@ -288,12 +287,13 @@ public sealed class BackendApiService : IBackendApiService, IDisposable
     }
 
     public async IAsyncEnumerable<ChatMessageData> SubscribeChatAsync(
-        string threadId, string bearerToken,
+        string threadId,
         [EnumeratorCancellation] CancellationToken cancellationToken = default)
     {
         var url = $"v1/forum/thread/{Uri.EscapeDataString(threadId)}/forum/sse";
         using var request = new HttpRequestMessage(HttpMethod.Get, url);
-        request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", bearerToken);
+        if (!string.IsNullOrWhiteSpace(_currentToken))
+            request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", _currentToken);
         request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("text/event-stream"));
 
         using var response = await _sseHttpClient.SendAsync(

--- a/Services/IBackendApiService.cs
+++ b/Services/IBackendApiService.cs
@@ -8,14 +8,16 @@ namespace d2c_launcher.Services;
 
 public interface IBackendApiService
 {
-    Task<PartySnapshot> GetMyPartySnapshotAsync(string bearerToken, CancellationToken cancellationToken = default);
+    /// <summary>Sets the bearer token used for all authenticated API calls. Pass null to clear.</summary>
+    void SetBearerToken(string? token);
+    Task<PartySnapshot> GetMyPartySnapshotAsync(CancellationToken cancellationToken = default);
     Task<IReadOnlyList<MatchmakingModeInfo>> GetEnabledMatchmakingModesAsync(CancellationToken cancellationToken = default);
     Task<IReadOnlyList<InviteCandidateView>> SearchPlayersAsync(string name, int count = 25, CancellationToken cancellationToken = default);
-    Task<(string? Name, string? AvatarUrl)?> GetUserInfoAsync(string steamId, string bearerToken, CancellationToken cancellationToken = default);
+    Task<(string? Name, string? AvatarUrl)?> GetUserInfoAsync(string steamId, CancellationToken cancellationToken = default);
     Task<(int InGame, int OnSite)> GetOnlineStatsAsync(CancellationToken cancellationToken = default);
-    Task<IReadOnlyList<ChatMessageData>> GetChatMessagesAsync(string threadId, int limit, string bearerToken, CancellationToken cancellationToken = default);
-    Task PostChatMessageAsync(string threadId, string content, string bearerToken, CancellationToken cancellationToken = default);
-    IAsyncEnumerable<ChatMessageData> SubscribeChatAsync(string threadId, string bearerToken, CancellationToken cancellationToken = default);
+    Task<IReadOnlyList<ChatMessageData>> GetChatMessagesAsync(string threadId, int limit, CancellationToken cancellationToken = default);
+    Task PostChatMessageAsync(string threadId, string content, CancellationToken cancellationToken = default);
+    IAsyncEnumerable<ChatMessageData> SubscribeChatAsync(string threadId, CancellationToken cancellationToken = default);
     Task<IReadOnlyList<EmoticonData>> GetEmoticonsAsync(CancellationToken cancellationToken = default);
     /// <summary>Returns the live match with the given ID, or null if not found.</summary>
     Task<LiveMatchInfo?> GetLiveMatchAsync(int matchId, CancellationToken cancellationToken = default);

--- a/ViewModels/ChatViewModel.cs
+++ b/ViewModels/ChatViewModel.cs
@@ -34,8 +34,6 @@ public partial class ChatViewModel : ViewModelBase, IDisposable
     private (string AuthorSteamId, string CreatedAt)? _lastMessageRaw;
     private HashSet<string> _onlineUsers = new(StringComparer.Ordinal);
 
-    public Func<string?> GetBackendToken { get; set; } = () => null;
-
     public ObservableCollection<ChatMessageView> Messages { get; } = new();
 
     [ObservableProperty] private string _inputText = "";
@@ -107,17 +105,9 @@ public partial class ChatViewModel : ViewModelBase, IDisposable
     {
         while (!ct.IsCancellationRequested)
         {
-            var token = GetBackendToken();
-            if (string.IsNullOrWhiteSpace(token))
-            {
-                try { await Task.Delay(5000, ct).ConfigureAwait(false); }
-                catch (OperationCanceledException) { break; }
-                continue;
-            }
-
             try
             {
-                await foreach (var msg in _backendApiService.SubscribeChatAsync(ThreadId, token, ct))
+                await foreach (var msg in _backendApiService.SubscribeChatAsync(ThreadId, ct))
                     ConsumeIncomingMessage(msg);
             }
             catch (OperationCanceledException) when (ct.IsCancellationRequested)
@@ -200,13 +190,6 @@ public partial class ChatViewModel : ViewModelBase, IDisposable
 
     public async Task RefreshAsync()
     {
-        var token = GetBackendToken();
-        if (string.IsNullOrWhiteSpace(token))
-        {
-            AppLog.Info("Chat: skipping refresh, no token.");
-            return;
-        }
-
         _loadCts?.Cancel();
         _loadCts = new CancellationTokenSource();
         var ct = _loadCts.Token;
@@ -216,7 +199,7 @@ public partial class ChatViewModel : ViewModelBase, IDisposable
             Dispatcher.UIThread.Post(() => IsLoading = Messages.Count == 0);
 
             var data = await _backendApiService.GetChatMessagesAsync(
-                ThreadId, MessageLimit, token, ct).ConfigureAwait(false);
+                ThreadId, MessageLimit, ct).ConfigureAwait(false);
 
             AppLog.Info($"Chat: received {data.Count} messages from API.");
 
@@ -247,15 +230,12 @@ public partial class ChatViewModel : ViewModelBase, IDisposable
         var text = InputText.Trim();
         if (string.IsNullOrEmpty(text)) return;
 
-        var token = GetBackendToken();
-        if (string.IsNullOrWhiteSpace(token)) return;
-
         IsSending = true;
         var saved = text;
         try
         {
             InputText = "";
-            await _backendApiService.PostChatMessageAsync(ThreadId, text, token)
+            await _backendApiService.PostChatMessageAsync(ThreadId, text)
                 .ConfigureAwait(false);
             // SSE will deliver the sent message — no manual refresh needed.
         }
@@ -338,16 +318,14 @@ public partial class ChatViewModel : ViewModelBase, IDisposable
 
     private async Task LoadUserAsync(string steamId)
     {
-        var token = GetBackendToken();
-        if (string.IsNullOrWhiteSpace(token))
+        var info = await _backendApiService.GetUserInfoAsync(steamId).ConfigureAwait(false);
+        if (info == null)
         {
-            // No token yet — remove from cache so it retries next time.
+            // No token yet or user not found — remove from cache so it retries next time.
             _userNameCache.Remove(steamId);
             return;
         }
-
-        var info = await _backendApiService.GetUserInfoAsync(steamId, token).ConfigureAwait(false);
-        var name = info?.Name ?? steamId;
+        var name = info.Value.Name ?? steamId;
 
         Dispatcher.UIThread.Post(() =>
         {

--- a/ViewModels/MainLauncherViewModel.cs
+++ b/ViewModels/MainLauncherViewModel.cs
@@ -103,6 +103,8 @@ public partial class MainLauncherViewModel : ViewModelBase, IDisposable
 
         var settings = settingsStorage.Get();
         _backendAccessToken = settings.BackendAccessToken;
+        if (!string.IsNullOrWhiteSpace(_backendAccessToken))
+            _backendApiService.SetBearerToken(_backendAccessToken);
         _isIntroOpen = !settings.IntroShown;
         _currentUser = steamManager.CurrentUser;
         _avatarImage = SteamAvatarHelper.FromUser(_currentUser);
@@ -126,15 +128,12 @@ public partial class MainLauncherViewModel : ViewModelBase, IDisposable
         Settings.PushCvar = PushCvarIfGameRunning;
         Settings.OnDlcChanged = removedIds => OnDlcChanged?.Invoke(removedIds);
         Chat = new ChatViewModel(backendApiService, imageService, emoticonService, queueSocketService);
-        Chat.GetBackendToken = () => BackendAccessToken;
         _ = Chat.StartAsync();
 
         // Wire delegates into children that need auth state
         Room.GetCurrentUser = () => CurrentUser;
-        Room.GetBackendToken = () => BackendAccessToken;
         Room.GetModeName = mode =>
             Queue.MatchmakingModes.FirstOrDefault(m => m.ModeId == (int)mode)?.Name ?? mode.ToString();
-        Party.GetBackendToken = () => BackendAccessToken;
 
         // Keep queue timer in sync with party queue time
         Party.EnterQueueAtChanged += time => Queue.SetEnterQueueAt(time);
@@ -299,6 +298,7 @@ public partial class MainLauncherViewModel : ViewModelBase, IDisposable
         {
             AppLog.Info("Backend token cleared.");
             BackendAccessToken = null;
+            _backendApiService.SetBearerToken(null);
             PersistBackendToken(null);
             await EnsureQueueConnectionAsync(null, ct);
             Party.ClearParty();
@@ -309,6 +309,7 @@ public partial class MainLauncherViewModel : ViewModelBase, IDisposable
         {
             AppLog.Info("Backend token received from bridge.");
             BackendAccessToken = token;
+            _backendApiService.SetBearerToken(token);
             PersistBackendToken(token);
             await EnsureQueueConnectionAsync(token, ct);
             await Party.RefreshPartyAsync();
@@ -325,6 +326,7 @@ public partial class MainLauncherViewModel : ViewModelBase, IDisposable
 
             AppLog.Error("Backend token application failed.", ex);
             BackendAccessToken = null;
+            _backendApiService.SetBearerToken(null);
             PersistBackendToken(null);
             await EnsureQueueConnectionAsync(null, ct);
             Party.ClearParty();

--- a/ViewModels/PartyViewModel.cs
+++ b/ViewModels/PartyViewModel.cs
@@ -22,9 +22,6 @@ public partial class PartyViewModel : ViewModelBase, IDisposable
     private int _partyRefreshRunning;
     private System.Collections.Generic.HashSet<string> _onlineUsers = new(StringComparer.Ordinal);
 
-    // Delegate set by parent
-    public Func<string?> GetBackendToken { get; set; } = () => null;
-
     [ObservableProperty]
     private ObservableCollection<PartyMemberView> _partyMembers = new();
 
@@ -84,15 +81,7 @@ public partial class PartyViewModel : ViewModelBase, IDisposable
 
         try
         {
-            var token = GetBackendToken();
-            if (string.IsNullOrWhiteSpace(token))
-            {
-                AppLog.Info("Party refresh skipped: no backend token.");
-                ClearParty();
-                return;
-            }
-
-            var partySnapshot = await _backendApiService.GetMyPartySnapshotAsync(token);
+            var partySnapshot = await _backendApiService.GetMyPartySnapshotAsync();
             PartyMembers.Clear();
             foreach (var m in partySnapshot.Members)
                 PartyMembers.Add(m);

--- a/ViewModels/RoomViewModel.cs
+++ b/ViewModels/RoomViewModel.cs
@@ -19,7 +19,6 @@ public partial class RoomViewModel : ViewModelBase
 
     // Delegates set by parent after construction
     public Func<Models.User?> GetCurrentUser { get; set; } = () => null;
-    public Func<string?> GetBackendToken { get; set; } = () => null;
     public Func<MatchmakingMode, string> GetModeName { get; set; } = m => m.ToString();
 
     [ObservableProperty]
@@ -170,10 +169,7 @@ public partial class RoomViewModel : ViewModelBase
 
     private async Task<(string? Name, string? AvatarUrl)?> FetchUserInfoAsync(string steamId)
     {
-        var token = GetBackendToken();
-        if (string.IsNullOrWhiteSpace(token))
-            return null;
-        return await _backendApiService.GetUserInfoAsync(steamId, token);
+        return await _backendApiService.GetUserInfoAsync(steamId);
     }
 
     private void AcceptGame()

--- a/memory-bank/activeContext.md
+++ b/memory-bank/activeContext.md
@@ -2,6 +2,24 @@
 
 ## Current Focus
 
+### Refactoring: MainLauncherViewModel god class
+
+**Goal:** Reduce MLVM from 376 lines / 10 concerns to ~160 lines (thin coordinator).
+
+**Planned extractions:**
+1. **`SetBearerToken` on `BackendApiService`** *(in progress)* — Centralize auth token on the HTTP client. Drop `bearerToken` parameter from all 5 authenticated API methods. Drop `GetBackendToken` delegates from `PartyViewModel`, `RoomViewModel`, `ChatViewModel`. MLVM calls `_backendApiService.SetBearerToken(token)` once in `ApplyBackendTokenAsync`.
+2. **Extract `AuthCoordinator`** — Move `ApplyBackendTokenAsync`, `EnsureQueueConnectionAsync`, `PersistBackendToken`, `_ticketExchangeCts` + Steam event subscription out of MLVM into a dedicated coordinator class.
+3. **Extract `OnlineStatsViewModel`** — Move `_onlineStatsTimer`, `RefreshInGameCountAsync`, socket `OnlineUpdated` handler, `OnlineInGame/Sessions/StatsText` into a child VM. XAML binds to `OnlineStats.Text`.
+4. **Extract `UserProfileViewModel`** — Move `CurrentUser`, `AvatarImage`, `LoggedInAsText`, `OnUserUpdated` handler into a child VM.
+5. **Extract `SocketSoundCoordinator`** — Move 4 socket event → sound/notification handlers into a plain class.
+
+**Files to create:** `Services/AuthCoordinator.cs`, `ViewModels/OnlineStatsViewModel.cs`, `ViewModels/UserProfileViewModel.cs`, `Integration/SocketSoundCoordinator.cs`
+**Files to modify:** `IBackendApiService.cs`, `BackendApiService.cs`, `PartyViewModel.cs`, `RoomViewModel.cs`, `ChatViewModel.cs`, `MainLauncherViewModel.cs`, `Preview/PreviewStubs.cs`, relevant XAML
+
+---
+
+## Previous Focus
+
 **Issue #40: dota_camera_distance not persisting**
 
 Root cause: the game client overwrites `config.cfg` on exit, wiping any cvars it doesn't manage (like `dota_camera_distance`).


### PR DESCRIPTION
Replaced the per-call bearerToken parameter pattern with a single SetBearerToken(string?) method on IBackendApiService. The token is set once when auth state changes and reused by all authenticated calls.

- IBackendApiService: add SetBearerToken; remove bearerToken param from GetMyPartySnapshotAsync, GetUserInfoAsync, GetChatMessagesAsync, PostChatMessageAsync, SubscribeChatAsync
- BackendApiService: implement SetBearerToken (sets _currentToken + _authHttpClient auth header); fix startup bug where persisted token was never applied to _authHttpClient
- PartyViewModel, RoomViewModel, ChatViewModel: remove GetBackendToken delegate; call API methods without token parameter
- MainLauncherViewModel: call SetBearerToken on all auth state changes; remove 3x GetBackendToken delegate assignments
- PreviewStubs, PreviewRegistry: updated to match new interface