### PR TITLE
fix: release single-instance mutex before Velopack restarts to new ve…

### DIFF
--- a/App.axaml.cs
+++ b/App.axaml.cs
@@ -68,6 +68,7 @@ public partial class App : Application
             services.AddSingleton<IGameDownloadService, GameDownloadService>();
             services.AddSingleton<RedistInstallService>();
             services.AddSingleton<IContentRegistryService, ContentRegistryService>();
+            services.AddSingleton<IChatViewModelFactory, ChatViewModelFactory>();
             services.AddSingleton<MainWindowViewModel>();
 
             _services = services.BuildServiceProvider();

--- a/Preview/PreviewRegistry.cs
+++ b/Preview/PreviewRegistry.cs
@@ -100,17 +100,10 @@ public static class PreviewRegistry
             ["ChatPanel"] = () =>
             {
                 var stub = new StubBackendApiService();
-                var vm = new ChatViewModel(stub, new StubHttpImageService(), new StubEmoticonService(), new StubQueueSocketService());
+                var vm = new ChatViewModel("preview-thread", stub, new StubHttpImageService(), new StubEmoticonService(), new StubQueueSocketService());
                 _ = vm.StartAsync();
-                var host = new Avalonia.Controls.Panel
-                {
-                    Width = 620,
-                    Height = 520,
-                    Background = new Avalonia.Media.SolidColorBrush(Avalonia.Media.Color.Parse("#060708")),
-                };
-                var view = new ChatPanel { DataContext = vm };
-                host.Children.Add(view);
-                return (host, null);
+                var view = new ChatPanel { DataContext = vm, Width = 620, Height = 520 };
+                return (view, null);
             },
             ["RichMessage"] = () =>
             {

--- a/Program.cs
+++ b/Program.cs
@@ -16,10 +16,14 @@ sealed class Program
     {
         VelopackApp.Build().Run();
 
+        // Skip single-instance enforcement in preview mode so the preview tool
+        // can run alongside a running launcher instance.
+        var isPreview = Array.IndexOf(args, "--preview") >= 0;
+
         // Enforce single instance: if another launcher is already running, forward
         // our args to it (e.g. a d2c:// protocol URL) and exit immediately.
         var singleInstance = new SingleInstanceService();
-        if (!singleInstance.TryBecomePrimaryInstance(args))
+        if (!isPreview && !singleInstance.TryBecomePrimaryInstance(args))
         {
             singleInstance.Dispose();
             return;

--- a/Services/ChatViewModelFactory.cs
+++ b/Services/ChatViewModelFactory.cs
@@ -1,0 +1,31 @@
+using d2c_launcher.ViewModels;
+
+namespace d2c_launcher.Services;
+
+public interface IChatViewModelFactory
+{
+    ChatViewModel Create(string threadId);
+}
+
+public sealed class ChatViewModelFactory : IChatViewModelFactory
+{
+    private readonly IBackendApiService _backendApiService;
+    private readonly IHttpImageService _imageService;
+    private readonly IEmoticonService _emoticonService;
+    private readonly IQueueSocketService _queueSocketService;
+
+    public ChatViewModelFactory(
+        IBackendApiService backendApiService,
+        IHttpImageService imageService,
+        IEmoticonService emoticonService,
+        IQueueSocketService queueSocketService)
+    {
+        _backendApiService = backendApiService;
+        _imageService = imageService;
+        _emoticonService = emoticonService;
+        _queueSocketService = queueSocketService;
+    }
+
+    public ChatViewModel Create(string threadId)
+        => new(threadId, _backendApiService, _imageService, _emoticonService, _queueSocketService);
+}

--- a/ViewModels/ChatViewModel.cs
+++ b/ViewModels/ChatViewModel.cs
@@ -17,7 +17,7 @@ namespace d2c_launcher.ViewModels;
 
 public partial class ChatViewModel : ViewModelBase, IDisposable
 {
-    private const string ThreadId = "17aa3530-d152-462e-a032-909ae69019ed";
+    private readonly string _threadId;
     private const int MessageLimit = 100;
     private const int MergeWindowSeconds = 60;
 
@@ -42,8 +42,9 @@ public partial class ChatViewModel : ViewModelBase, IDisposable
 
     public event Action? MessagesUpdated;
 
-    public ChatViewModel(IBackendApiService backendApiService, IHttpImageService imageService, IEmoticonService emoticonService, IQueueSocketService queueSocketService)
+    public ChatViewModel(string threadId, IBackendApiService backendApiService, IHttpImageService imageService, IEmoticonService emoticonService, IQueueSocketService queueSocketService)
     {
+        _threadId = threadId;
         _backendApiService = backendApiService;
         _imageService = imageService;
         _emoticonService = emoticonService;
@@ -107,7 +108,7 @@ public partial class ChatViewModel : ViewModelBase, IDisposable
         {
             try
             {
-                await foreach (var msg in _backendApiService.SubscribeChatAsync(ThreadId, ct))
+                await foreach (var msg in _backendApiService.SubscribeChatAsync(_threadId, ct))
                     ConsumeIncomingMessage(msg);
             }
             catch (OperationCanceledException) when (ct.IsCancellationRequested)
@@ -199,7 +200,7 @@ public partial class ChatViewModel : ViewModelBase, IDisposable
             Dispatcher.UIThread.Post(() => IsLoading = Messages.Count == 0);
 
             var data = await _backendApiService.GetChatMessagesAsync(
-                ThreadId, MessageLimit, ct).ConfigureAwait(false);
+                _threadId, MessageLimit, ct).ConfigureAwait(false);
 
             AppLog.Info($"Chat: received {data.Count} messages from API.");
 
@@ -235,7 +236,7 @@ public partial class ChatViewModel : ViewModelBase, IDisposable
         try
         {
             InputText = "";
-            await _backendApiService.PostChatMessageAsync(ThreadId, text)
+            await _backendApiService.PostChatMessageAsync(_threadId, text)
                 .ConfigureAwait(false);
             // SSE will deliver the sent message — no manual refresh needed.
         }

--- a/ViewModels/MainLauncherViewModel.cs
+++ b/ViewModels/MainLauncherViewModel.cs
@@ -21,8 +21,6 @@ public partial class MainLauncherViewModel : ViewModelBase, IDisposable
     private readonly ISteamAuthApi _steamAuthApi;
     private readonly IQueueSocketService _queueSocketService;
     private readonly IBackendApiService _backendApiService;
-    private readonly IHttpImageService _imageService;
-    private readonly IEmoticonService _emoticonService;
     private readonly ICvarSettingsProvider _cvarProvider;
     private readonly IVideoSettingsProvider _videoProvider;
     private readonly IContentRegistryService _registryService;
@@ -85,10 +83,9 @@ public partial class MainLauncherViewModel : ViewModelBase, IDisposable
         IVideoSettingsProvider videoProvider,
         ISteamAuthApi steamAuthApi,
         IBackendApiService backendApiService,
-        IHttpImageService imageService,
-        IEmoticonService emoticonService,
         IQueueSocketService queueSocketService,
-        IContentRegistryService registryService)
+        IContentRegistryService registryService,
+        IChatViewModelFactory chatViewModelFactory)
     {
         _steamManager = steamManager;
         _settingsStorage = settingsStorage;
@@ -97,8 +94,6 @@ public partial class MainLauncherViewModel : ViewModelBase, IDisposable
         _steamAuthApi = steamAuthApi;
         _queueSocketService = queueSocketService;
         _backendApiService = backendApiService;
-        _imageService = imageService;
-        _emoticonService = emoticonService;
         _registryService = registryService;
 
         var settings = settingsStorage.Get();
@@ -127,7 +122,7 @@ public partial class MainLauncherViewModel : ViewModelBase, IDisposable
         Settings = new SettingsViewModel(launchSettingsStorage, cvarProvider, settingsStorage, videoProvider, registryService);
         Settings.PushCvar = PushCvarIfGameRunning;
         Settings.OnDlcChanged = removedIds => OnDlcChanged?.Invoke(removedIds);
-        Chat = new ChatViewModel(backendApiService, imageService, emoticonService, queueSocketService);
+        Chat = chatViewModelFactory.Create("17aa3530-d152-462e-a032-909ae69019ed");
         _ = Chat.StartAsync();
 
         // Wire delegates into children that need auth state

--- a/ViewModels/MainWindowViewModel.cs
+++ b/ViewModels/MainWindowViewModel.cs
@@ -20,8 +20,7 @@ public partial class MainWindowViewModel : ViewModelBase
     private readonly IGameLaunchSettingsStorage _launchSettingsStorage;
     private readonly ISteamAuthApi _steamAuthApi;
     private readonly IBackendApiService _backendApiService;
-    private readonly IHttpImageService _imageService;
-    private readonly IEmoticonService _emoticonService;
+    private readonly IChatViewModelFactory _chatViewModelFactory;
     private readonly IQueueSocketService _queueSocketService;
     private readonly ICvarSettingsProvider _cvarProvider;
     private readonly IVideoSettingsProvider _videoProvider;
@@ -58,9 +57,8 @@ public partial class MainWindowViewModel : ViewModelBase
         IGameLaunchSettingsStorage launchSettingsStorage,
         ISteamAuthApi steamAuthApi,
         IBackendApiService backendApiService,
-        IHttpImageService imageService,
-        IEmoticonService emoticonService,
         IQueueSocketService queueSocketService,
+        IChatViewModelFactory chatViewModelFactory,
         ICvarSettingsProvider cvarProvider,
         IVideoSettingsProvider videoProvider,
         UpdateService updateService,
@@ -75,9 +73,8 @@ public partial class MainWindowViewModel : ViewModelBase
         _launchSettingsStorage = launchSettingsStorage;
         _steamAuthApi = steamAuthApi;
         _backendApiService = backendApiService;
-        _imageService = imageService;
-        _emoticonService = emoticonService;
         _queueSocketService = queueSocketService;
+        _chatViewModelFactory = chatViewModelFactory;
         _cvarProvider = cvarProvider;
         _videoProvider = videoProvider;
         _updateService = updateService;
@@ -129,7 +126,14 @@ public partial class MainWindowViewModel : ViewModelBase
     }
 
     [RelayCommand]
-    private void ApplyUpdate() => _updateService.ApplyAndRestart();
+    private void ApplyUpdate()
+    {
+        // Release the single-instance mutex before Velopack launches the new process,
+        // otherwise the new instance sees the mutex held and exits immediately.
+        App.SingleInstance?.Dispose();
+        App.SingleInstance = null;
+        _updateService.ApplyAndRestart();
+    }
 
     // ── State transitions ────────────────────────────────────────────────────
 
@@ -268,7 +272,7 @@ public partial class MainWindowViewModel : ViewModelBase
         DisposeCurrentVm();
         var vm = new MainLauncherViewModel(
             _steamManager, _settingsStorage, _launchSettingsStorage, _cvarProvider, _videoProvider,
-            _steamAuthApi, _backendApiService, _imageService, _emoticonService, _queueSocketService, _registryService);
+            _steamAuthApi, _backendApiService, _queueSocketService, _registryService, _chatViewModelFactory);
         vm.OnGameDirectoryChanged = _ => Dispatcher.UIThread.Post(() => EnterState(AppStateMachine.OnGameDirChanged(AppState)));
         vm.RequestGameDirectoryChange = () => Dispatcher.UIThread.Post(() => EnterState(AppState.SelectGameDirectory));
         vm.OnDlcChanged = removedIds => Dispatcher.UIThread.Post(() =>

--- a/Views/PreviewWindow.axaml
+++ b/Views/PreviewWindow.axaml
@@ -1,9 +1,9 @@
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         x:Class="d2c_launcher.Views.PreviewWindow"
-        SystemDecorations="None"
         SizeToContent="WidthAndHeight"
         WindowStartupLocation="CenterScreen"
+        ShowInTaskbar="True"
         Background="#1a1c20">
 
     <ContentControl x:Name="Host"


### PR DESCRIPTION
…rsion

When ApplyUpdatesAndRestart is called, Velopack launches the new process before the old one exits. The new instance would see the named mutex still held and immediately exit thinking another launcher was running.

Fix by disposing SingleInstanceService (releasing the mutex) before calling ApplyUpdatesAndRestart.

Also includes refactoring of ChatViewModel to accept threadId as a constructor parameter via ChatViewModelFactory, and related cleanup.