### PR TITLE
fix: make Dotaclassic Plus badge clickable to open store

### DIFF
--- a/Views/Components/ChatPanel.axaml
+++ b/Views/Components/ChatPanel.axaml
@@ -155,20 +155,33 @@
                                                                                 Foreground="#9E9E9E"
                                                                                 IsVisible="{Binding IsAdmin}"
                                                                                 ToolTip.Tip="{util:T 'chat.roleAdminTooltip'}"/>
-                                                    <!-- OLD subscriber: custom chat icon (GIF-capable) or star fallback -->
-                                                    <Panel IsVisible="{Binding IsOld}"
-                                                           Width="16" Height="16"
-                                                           ToolTip.Tip="{Binding ChatIconTooltip}">
-                                                        <components:EmoticonImage
-                                                            Bytes="{Binding ChatIconBytes}"
-                                                            Width="16" Height="16"/>
-                                                        <materialIcons:MaterialIcon Kind="Star"
-                                                                                    Width="14" Height="14"
-                                                                                    Foreground="#FFD700"
-                                                                                    HorizontalAlignment="Center"
-                                                                                    VerticalAlignment="Center"
-                                                                                    IsVisible="{Binding ChatIconBytes, Converter={x:Static ObjectConverters.IsNull}}"/>
-                                                    </Panel>
+                                                    <!-- OLD subscriber: custom chat icon (GIF-capable) or star fallback; click opens store -->
+                                                    <Button IsVisible="{Binding IsOld}"
+                                                            Width="16" Height="16"
+                                                            Padding="0"
+                                                            Background="Transparent"
+                                                            BorderThickness="0"
+                                                            Cursor="Hand"
+                                                            ToolTip.Tip="{Binding ChatIconTooltip}"
+                                                            Click="OnDotaclassicPlusClicked">
+                                                        <Button.Styles>
+                                                            <Style Selector="Button:pointerover /template/ ContentPresenter">
+                                                                <Setter Property="Background" Value="Transparent"/>
+                                                                <Setter Property="Opacity" Value="0.8"/>
+                                                            </Style>
+                                                        </Button.Styles>
+                                                        <Panel Width="16" Height="16">
+                                                            <components:EmoticonImage
+                                                                Bytes="{Binding ChatIconBytes}"
+                                                                Width="16" Height="16"/>
+                                                            <materialIcons:MaterialIcon Kind="Star"
+                                                                                        Width="14" Height="14"
+                                                                                        Foreground="#FFD700"
+                                                                                        HorizontalAlignment="Center"
+                                                                                        VerticalAlignment="Center"
+                                                                                        IsVisible="{Binding ChatIconBytes, Converter={x:Static ObjectConverters.IsNull}}"/>
+                                                        </Panel>
+                                                    </Button>
                                                 </StackPanel>
                                                 <TextBlock Grid.Column="2"
                                                            Text="{Binding TimeText}"

--- a/Views/Components/ChatPanel.axaml.cs
+++ b/Views/Components/ChatPanel.axaml.cs
@@ -60,6 +60,9 @@ public partial class ChatPanel : UserControl
     private void OnSiteClicked(object? sender, RoutedEventArgs e) =>
         Process.Start(new ProcessStartInfo("https://dotaclassic.ru/") { UseShellExecute = true });
 
+    private void OnDotaclassicPlusClicked(object? sender, RoutedEventArgs e) =>
+        Process.Start(new ProcessStartInfo("https://dotaclassic.ru/store") { UseShellExecute = true });
+
     private void OnPickerReactClicked(object? sender, RoutedEventArgs e)
     {
         if (sender is Control v &&


### PR DESCRIPTION
## Summary
- The Dotaclassic Plus badge (star/custom icon shown next to subscriber names in chat) is now a clickable `Button`
- Clicking it opens `https://dotaclassic.ru/store` in the default browser
- Hover dims the badge slightly (opacity 0.8) for visual feedback

## Test plan
- [ ] Find a chat message from a Dotaclassic Plus subscriber
- [ ] Click the star/icon badge next to their name
- [ ] Confirm `https://dotaclassic.ru/store` opens in the browser
- [ ] Confirm tooltip still appears on hover
- [ ] Confirm the badge has a pointer cursor on hover

Closes #102

🤖 Generated with [Claude Code](https://claude.com/claude-code)