### PR TITLE
chore: strip ~50 MB WinForms dead weight from install

### DIFF
--- a/Util/SoundPlayer.cs
+++ b/Util/SoundPlayer.cs
@@ -27,7 +27,7 @@ public static class SoundPlayer
                 {
                     WaveStream reader = Path.GetExtension(fileName).ToLowerInvariant() switch
                     {
-                        ".mp3" => new Mp3FileReader(stream),
+                        ".mp3" => new Mp3FileReaderBase(stream, wf => new AcmMp3FrameDecompressor(wf)),
                         ".wav" => new WaveFileReader(stream),
                         _ => throw new NotSupportedException($"Unsupported audio format: {fileName}")
                     };

--- a/d2c-launcher.csproj
+++ b/d2c-launcher.csproj
@@ -19,7 +19,7 @@
     <AvaloniaResource Include="Assets\**" />
     <ContentWithTargetPath Include="steam_api64.dll" CopyToOutputDirectory="PreserveNewest" TargetPath="steam_api64.dll" />
     <ContentWithTargetPath Include="steam_appid.txt" CopyToOutputDirectory="PreserveNewest" TargetPath="steam_appid.txt" />
-    <ContentWithTargetPath Include="Preview\livematch.json" CopyToOutputDirectory="PreserveNewest" TargetPath="Preview\livematch.json" />
+    <ContentWithTargetPath Include="Preview\livematch.json" Condition="'$(Configuration)' == 'Debug'" CopyToOutputDirectory="PreserveNewest" TargetPath="Preview\livematch.json" />
     <Compile Remove="SteamBridge\**\*.cs" />
     <Compile Remove="d2c-launcher.Tests\**\*.cs" />
   </ItemGroup>
@@ -39,7 +39,8 @@
     <PackageReference Include="DialogHost.Avalonia" Version="0.9.0" />
     <PackageReference Include="Material.Icons.Avalonia" Version="3.0.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.0" />
-    <PackageReference Include="NAudio" Version="2.2.1" />
+    <PackageReference Include="NAudio.Core" Version="2.2.1" />
+    <PackageReference Include="NAudio.WinMM" Version="2.2.1" />
     <PackageReference Include="SocketIOClient" Version="3.1.1" />
     <PackageReference Include="Steamworks.NET" Version="2024.8.0" />
     <PackageReference Include="System.Management" Version="9.0.0" />


### PR DESCRIPTION
## Summary

- Replace `NAudio` meta-package with `NAudio.Core` + `NAudio.WinMM` — the only two sub-packages the launcher actually uses
- Adapt `SoundPlayer.cs` to use `Mp3FileReaderBase + AcmMp3FrameDecompressor` directly (identical behaviour, no NAudio stub DLL needed)
- Exclude `Preview/livematch.json` from non-Debug builds (dev-tool data file, no use in production)

## What gets removed from the install

| File | Size |
|---|---|
| `System.Windows.Forms.dll` | 14 MB |
| `System.Windows.Forms.Design.dll` | 5.9 MB |
| `System.Windows.Forms.Primitives.dll` | 3.5 MB |
| `System.Private.Windows.Core.dll` | 1.9 MB |
| `NAudio.WinForms.dll`, `NAudio.Asio.dll`, `NAudio.Midi.dll`, `NAudio.Wasapi.dll` | ~1 MB |
| `System.Drawing.Common.dll`, `Accessibility.dll`, `Microsoft.VisualBasic.Forms.dll`, etc. | ~5 MB |
| 13 locale satellite folders (`cs/`, `de/`, `es/`, `fr/`, `it/`, `ja/`, `ko/`, `pl/`, `pt-BR/`, `ru/`, `tr/`, `zh-Hans/`, `zh-Hant/`) — all WinForms resources | ~10 MB |
| **Total** | **~50 MB** |

None of these were used. They were all dragged in because `NAudio.WinForms.dll` references `System.Windows.Forms`.

## Test plan

- [x] Build succeeds (`dotnet build`)
- [x] Audio plays in-game (notification sounds, queue sounds)
- [x] Install size is reduced by ~50 MB on next publish

🤖 Generated with [Claude Code](https://claude.com/claude-code)