### PR TITLE
feat: Windows Vista compatibility mode setting for dota.exe

### DIFF
--- a/Resources/Strings.cs
+++ b/Resources/Strings.cs
@@ -28,10 +28,8 @@ public static class Strings
     public static string CloseToTrayDescription => I18n.T("settings.closeToTrayDescription");
     public static string AutoConnectToServer    => I18n.T("settings.autoConnectToServer");
     public static string AutoConnectDescription => I18n.T("settings.autoConnectDescription");
-    public static string DefenderExclusionTitle       => I18n.T("settings.defenderExclusionTitle");
-    public static string DefenderExclusionAdded       => I18n.T("settings.defenderExclusionAdded");
-    public static string VistaCompatibilityTitle      => I18n.T("settings.vistaCompatibilityTitle");
-    public static string VistaCompatibilityDescription => I18n.T("settings.vistaCompatibilityDescription");
+    public static string DefenderExclusionTitle => I18n.T("settings.defenderExclusionTitle");
+    public static string DefenderExclusionAdded => I18n.T("settings.defenderExclusionAdded");
     public static string LaunchParameters       => I18n.T("settings.launchParameters");
     public static string ExtraArgsHint          => I18n.T("settings.extraArgsHint");
     public static string UiScale                => I18n.T("settings.uiScale");

--- a/Services/FaroTelemetryService.cs
+++ b/Services/FaroTelemetryService.cs
@@ -31,10 +31,16 @@ public static class FaroTelemetryService
     private static Dictionary<string, string> _hwAttributes = [];
     private static string _osName = "Windows";
 
-    /// <summary>GPU vendor string derived from hardware snapshot: "AMD", "NVIDIA", "Intel", or "Unknown".</summary>
+    /// <summary>
+    /// GPU vendor string derived from hardware snapshot: "AMD", "NVIDIA", "Intel", or "Unknown".
+    /// Written once at startup (via <see cref="Init"/> → <see cref="ApplyHardware"/>) before any reads.
+    /// </summary>
     public static string GpuVendor { get; private set; } = "Unknown";
 
-    /// <summary>OS build number string (e.g. "19045") derived from hardware snapshot.</summary>
+    /// <summary>
+    /// OS build number string (e.g. "19045") derived from hardware snapshot.
+    /// Written once at startup (via <see cref="Init"/> → <see cref="ApplyHardware"/>) before any reads.
+    /// </summary>
     public static string OsBuild { get; private set; } = "?";
 
     private static readonly ConcurrentQueue<FaroLog> LogQueue = new();
@@ -137,13 +143,16 @@ public static class FaroTelemetryService
     {
         foreach (var gpu in gpus)
         {
-            if (gpu.Contains("AMD", StringComparison.OrdinalIgnoreCase) ||
-                gpu.Contains("Radeon", StringComparison.OrdinalIgnoreCase))
+            // Match only the name segment (before the first '|') — the full string is
+            // "Name | Driver: X | VRAM: Y MB"; searching the full string risks false positives.
+            var name = gpu.Split('|')[0];
+            if (name.Contains("AMD", StringComparison.OrdinalIgnoreCase) ||
+                name.Contains("Radeon", StringComparison.OrdinalIgnoreCase))
                 return "AMD";
-            if (gpu.Contains("NVIDIA", StringComparison.OrdinalIgnoreCase) ||
-                gpu.Contains("GeForce", StringComparison.OrdinalIgnoreCase))
+            if (name.Contains("NVIDIA", StringComparison.OrdinalIgnoreCase) ||
+                name.Contains("GeForce", StringComparison.OrdinalIgnoreCase))
                 return "NVIDIA";
-            if (gpu.Contains("Intel", StringComparison.OrdinalIgnoreCase))
+            if (name.Contains("Intel", StringComparison.OrdinalIgnoreCase))
                 return "Intel";
         }
         return "Unknown";

--- a/Services/WindowsCompatibilityService.cs
+++ b/Services/WindowsCompatibilityService.cs
@@ -54,13 +54,20 @@ public static class WindowsCompatibilityService
 
     /// <summary>
     /// Sets or clears the Vista compatibility layer for dota.exe at <paramref name="exePath"/>.
+    /// Returns true on success, false if the registry write failed.
     /// </summary>
-    public static void SetVistaCompat(string exePath, bool enabled)
+    public static bool SetVistaCompat(string exePath, bool enabled)
     {
         try
         {
             using var key = Registry.CurrentUser.OpenSubKey(LayersKeyPath, writable: true)
                 ?? Registry.CurrentUser.CreateSubKey(LayersKeyPath);
+
+            if (key == null)
+            {
+                AppLog.Error("[Compat] Could not open or create AppCompatFlags\\Layers (access denied?)");
+                return false;
+            }
 
             if (enabled)
                 key.SetValue(exePath, VistaCompatValue, RegistryValueKind.String);
@@ -68,10 +75,12 @@ public static class WindowsCompatibilityService
                 key.DeleteValue(exePath, throwOnMissingValue: false);
 
             AppLog.Info($"[Compat] Vista compat {(enabled ? "enabled" : "disabled")} for {exePath}");
+            return true;
         }
         catch (Exception ex)
         {
             AppLog.Error("[Compat] Failed to write AppCompatFlags", ex);
+            return false;
         }
     }
 
@@ -82,16 +91,21 @@ public static class WindowsCompatibilityService
     /// Heuristic: AMD/Radeon GPU present AND Windows build ≥ 14393 (Anniversary Update —
     /// the build that changed D3DCREATE_MIXED_VERTEXPROCESSING to force software VP).
     /// Source: Microsoft Compatibility Cookbook, "Changes in DX9 legacy support".
+    ///
+    /// Internal until a proactive-suggestion UI is wired up.
     /// </summary>
-    public static bool DetectNeedsCompat(HardwareSnapshot hw)
+    internal static bool DetectNeedsCompat(HardwareSnapshot hw)
     {
         if (!int.TryParse(hw.OsBuild, out var build) || build < 14393)
             return false;
 
         foreach (var gpu in hw.Gpus)
         {
-            if (gpu.Contains("AMD", StringComparison.OrdinalIgnoreCase) ||
-                gpu.Contains("Radeon", StringComparison.OrdinalIgnoreCase))
+            // Match only the name segment (before the first '|') to avoid false positives
+            // from driver version strings that might contain a vendor name incidentally.
+            var name = gpu.Split('|')[0];
+            if (name.Contains("AMD", StringComparison.OrdinalIgnoreCase) ||
+                name.Contains("Radeon", StringComparison.OrdinalIgnoreCase))
                 return true;
         }
 

--- a/ViewModels/GameLaunchViewModel.cs
+++ b/ViewModels/GameLaunchViewModel.cs
@@ -100,7 +100,10 @@ public partial class GameLaunchViewModel : ViewModelBase, IDisposable
 
     private readonly ServerUrlTracker _serverUrlTracker = new();
     private CancellationTokenSource? _connectCts;
-    private int? _lastProcessExitCode;
+    // Written from MonitorProcessAsync (thread pool), read from RefreshRunState (UI thread).
+    // volatile ensures the UI-thread read always sees the most recently written value.
+    // int.MinValue is the sentinel meaning "no exit code captured yet".
+    private volatile int _lastProcessExitCode = int.MinValue;
 
     private void UpdateServerUrl(PlayerGameStateMessage? msg)
     {
@@ -430,9 +433,9 @@ public partial class GameLaunchViewModel : ViewModelBase, IDisposable
                 _netConService.Disconnect();
                 var exitAttrs = new System.Collections.Generic.Dictionary<string, string>();
                 var exitCode = _lastProcessExitCode;
-                _lastProcessExitCode = null;
-                if (exitCode.HasValue)
-                    exitAttrs["exit_code"] = exitCode.Value.ToString();
+                _lastProcessExitCode = int.MinValue;
+                if (exitCode != int.MinValue)
+                    exitAttrs["exit_code"] = exitCode.ToString();
                 d2c_launcher.Services.FaroTelemetryService.TrackEvent("game_exited", exitAttrs);
                 if (!string.IsNullOrWhiteSpace(GameDirectory))
                 {

--- a/ViewModels/LauncherPrefsViewModel.cs
+++ b/ViewModels/LauncherPrefsViewModel.cs
@@ -19,11 +19,20 @@ public partial class LauncherPrefsViewModel : ViewModelBase
     [ObservableProperty] private string _gameDirectory = Strings.NotSpecified;
     [ObservableProperty] private string _folderSizeText = "";
 
+    public bool IsGameDirectorySet => !string.IsNullOrEmpty(_settingsStorage.Get().GameDirectory);
+
     public void RefreshGameDirectory()
     {
         var dir = _settingsStorage.Get().GameDirectory;
         GameDirectory = dir ?? Strings.NotSpecified;
         FolderSizeText = "";
+        OnPropertyChanged(nameof(IsGameDirectorySet));
+
+        // Refresh Vista compat state from registry — reads once per directory change
+        // rather than on every binding evaluation.
+        var exePath = string.IsNullOrEmpty(dir) ? null : Path.Combine(dir, "dota.exe");
+        _vistaCompatEnabled = exePath != null && WindowsCompatibilityService.IsVistaCompatEnabled(exePath);
+        OnPropertyChanged(nameof(VistaCompatibilityEnabled));
 
         if (!string.IsNullOrEmpty(dir) && Directory.Exists(dir))
         {
@@ -135,21 +144,25 @@ public partial class LauncherPrefsViewModel : ViewModelBase
         Dispatcher.UIThread.Post(() => OnPropertyChanged(nameof(DefenderExclusionEnabled)));
     }
 
+    // Cached so the getter doesn't perform a registry read on every binding evaluation.
+    // Refreshed in RefreshGameDirectory() and updated in the setter on successful write.
+    private bool _vistaCompatEnabled;
+
     public bool VistaCompatibilityEnabled
     {
-        get
-        {
-            var dir = _settingsStorage.Get().GameDirectory;
-            if (string.IsNullOrEmpty(dir)) return false;
-            var exePath = System.IO.Path.Combine(dir, "dota.exe");
-            return WindowsCompatibilityService.IsVistaCompatEnabled(exePath);
-        }
+        get => _vistaCompatEnabled;
         set
         {
             var dir = _settingsStorage.Get().GameDirectory;
-            if (string.IsNullOrEmpty(dir)) return;
-            var exePath = System.IO.Path.Combine(dir, "dota.exe");
-            WindowsCompatibilityService.SetVistaCompat(exePath, value);
+            if (string.IsNullOrEmpty(dir))
+            {
+                OnPropertyChanged(); // snap back — no game dir, nothing to write
+                return;
+            }
+            var exePath = Path.Combine(dir, "dota.exe");
+            var success = WindowsCompatibilityService.SetVistaCompat(exePath, value);
+            if (success)
+                _vistaCompatEnabled = value;
             OnPropertyChanged();
         }
     }
@@ -159,5 +172,13 @@ public partial class LauncherPrefsViewModel : ViewModelBase
     public LauncherPrefsViewModel(ISettingsStorage settingsStorage)
     {
         _settingsStorage = settingsStorage;
+
+        // Initialize Vista compat cache from registry at construction time.
+        var dir = settingsStorage.Get().GameDirectory;
+        if (!string.IsNullOrEmpty(dir))
+        {
+            var exePath = Path.Combine(dir, "dota.exe");
+            _vistaCompatEnabled = WindowsCompatibilityService.IsVistaCompatEnabled(exePath);
+        }
     }
 }

--- a/Views/Components/Settings/LauncherPrefsView.axaml
+++ b/Views/Components/Settings/LauncherPrefsView.axaml
@@ -2,6 +2,7 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:vm="using:d2c_launcher.ViewModels"
              xmlns:res="clr-namespace:d2c_launcher.Resources"
+             xmlns:l="clr-namespace:d2c_launcher.Util"
              x:Class="d2c_launcher.Views.Components.Settings.LauncherPrefsView"
              x:DataType="vm:LauncherPrefsViewModel">
 
@@ -85,10 +86,11 @@
             </CheckBox>
 
             <!-- Vista compatibility mode -->
-            <CheckBox IsChecked="{Binding VistaCompatibilityEnabled}">
+            <CheckBox IsChecked="{Binding VistaCompatibilityEnabled}"
+                      IsEnabled="{Binding IsGameDirectorySet}">
                 <StackPanel Spacing="2">
-                    <TextBlock Text="{x:Static res:Strings.VistaCompatibilityTitle}" Classes="setting-label"/>
-                    <TextBlock Text="{x:Static res:Strings.VistaCompatibilityDescription}" Classes="setting-desc"/>
+                    <TextBlock Text="{l:T 'settings.vistaCompatibilityTitle'}" Classes="setting-label"/>
+                    <TextBlock Text="{l:T 'settings.vistaCompatibilityDescription'}" Classes="setting-desc"/>
                 </StackPanel>
             </CheckBox>
 


### PR DESCRIPTION
## Summary

- Adds an opt-in **Windows Vista compatibility mode** checkbox to the **Лаунчер** settings tab
- Writes/clears the `VISTARTM` compat layer on `dota.exe` via `HKCU\Software\Microsoft\Windows NT\CurrentVersion\AppCompatFlags\Layers`
- Enriches Faro `game_launched` events with `gpu_vendor`, `os_build`, `vista_compat_enabled`; adds `exit_code` to `game_exited`; adds `gpu_vendor` to session attributes

## Root cause (documented in `WindowsCompatibilityService.cs`)

Two compounding regressions on Windows 10 build ≥ 14393:
1. **`D3DCREATE_MIXED_VERTEXPROCESSING` change** — Anniversary Update changed this flag to force software vertex processing on AMD. Source 1 engine uses this flag; the VersionLie shim causes the engine to select the HW vertex processing code path instead.
2. **Fullscreen Optimizations (FSO)** — Windows 10 silently converts D3D9 exclusive fullscreen to a DWM-composited borderless window. On AMD RDNA, the swap chain fails to present → game window is transparent (shows desktop). The `DISABLEDXMAXIMIZEDWINDOWEDMODE` shim disables FSO.

## Why opt-in, not default-on

Disabling FSO removes G-Sync on NVIDIA monitors. Not safe to auto-apply. Proactive suggestion (AMD GPU + build ≥ 14393 heuristic) is scaffolded in `WindowsCompatibilityService.DetectNeedsCompat()` but not wired to any UI prompt yet.

Closes #118