### PR TITLE
feat: dotakeys 684 profile migration + immutable server cfg exec

### DIFF
--- a/App.axaml.cs
+++ b/App.axaml.cs
@@ -98,6 +98,7 @@ public partial class App : Application
             services.AddSingleton<IChatViewModelFactory, ChatViewModelFactory>();
             services.AddSingleton<IWindowService, WindowService>();
             services.AddSingleton<INetConService, NetConService>();
+            services.AddSingleton<IDotakeysProfileService, DotakeysProfileService>();
             services.AddSingleton<MainWindowViewModel>();
 
             _services = services.BuildServiceProvider();

--- a/Preview/PreviewRegistry.cs
+++ b/Preview/PreviewRegistry.cs
@@ -70,7 +70,8 @@ public static class PreviewRegistry
                     new StubWindowService(),
                     new StubSteamAuthApi(),
                     new StubUiDispatcher(),
-                    new StubTriviaRepository(), new AvaloniaTimerFactory(), new StubNetConService(), new StubGameWindowService());
+                    new StubTriviaRepository(), new AvaloniaTimerFactory(), new StubNetConService(), new StubGameWindowService(),
+                    new StubDotakeysProfileService());
                 var view = new LauncherHeader { Width = 900, Height = 48, DataContext = vm };
                 return (view, null);
             },
@@ -82,7 +83,8 @@ public static class PreviewRegistry
                     new StubVideoSettingsProvider(), new StubBackendApiService(),
                     new StubQueueSocketService(), new StubContentRegistryService(),
                     new StubChatViewModelFactory(), new StubWindowService(), new StubSteamAuthApi(),
-                    new StubUiDispatcher(), new StubTriviaRepository(), new AvaloniaTimerFactory(), new StubNetConService(), new StubGameWindowService());
+                    new StubUiDispatcher(), new StubTriviaRepository(), new AvaloniaTimerFactory(), new StubNetConService(), new StubGameWindowService(),
+                    new StubDotakeysProfileService());
                 // Play state: game not running
                 vm.Launch.RunState = GameRunState.None;
                 var stack = new StackPanel { Spacing = 2, Background = new SolidColorBrush(Color.Parse("#1a1f26")) };
@@ -98,7 +100,8 @@ public static class PreviewRegistry
                     new StubVideoSettingsProvider(), new StubBackendApiService(),
                     new StubQueueSocketService(), new StubContentRegistryService(),
                     new StubChatViewModelFactory(), new StubWindowService(), new StubSteamAuthApi(),
-                    new StubUiDispatcher(), new StubTriviaRepository(), new AvaloniaTimerFactory(), new StubNetConService(), new StubGameWindowService());
+                    new StubUiDispatcher(), new StubTriviaRepository(), new AvaloniaTimerFactory(), new StubNetConService(), new StubGameWindowService(),
+                    new StubDotakeysProfileService());
                 // Stop state: our game is running
                 vm.Launch.RunState = GameRunState.OurGameRunning;
                 var stack = new StackPanel { Spacing = 2, Background = new SolidColorBrush(Color.Parse("#1a1f26")) };
@@ -738,14 +741,16 @@ public static class PreviewRegistry
                     new StubVideoSettingsProvider(), new StubBackendApiService(),
                     new StubQueueSocketService(), new StubContentRegistryService(),
                     new StubChatViewModelFactory(), new StubWindowService(), new StubSteamAuthApi(),
-                    new StubUiDispatcher(), new StubTriviaRepository(), new AvaloniaTimerFactory(), new StubNetConService(), new StubGameWindowService());
+                    new StubUiDispatcher(), new StubTriviaRepository(), new AvaloniaTimerFactory(), new StubNetConService(), new StubGameWindowService(),
+                    new StubDotakeysProfileService());
                 var launchVmStop = new MainLauncherViewModel(
                     new StubSteamManager(), new StubSettingsStorage(),
                     new StubGameLaunchSettingsStorage(), new StubCvarSettingsProvider(),
                     new StubVideoSettingsProvider(), new StubBackendApiService(),
                     new StubQueueSocketService(), new StubContentRegistryService(),
                     new StubChatViewModelFactory(), new StubWindowService(), new StubSteamAuthApi(),
-                    new StubUiDispatcher(), new StubTriviaRepository(), new AvaloniaTimerFactory(), new StubNetConService(), new StubGameWindowService());
+                    new StubUiDispatcher(), new StubTriviaRepository(), new AvaloniaTimerFactory(), new StubNetConService(), new StubGameWindowService(),
+                    new StubDotakeysProfileService());
                 launchVmStop.Launch.RunState = GameRunState.OurGameRunning;
                 col.Children.Add(new LauncherHeader { Width = 400, Height = 48, DataContext = launchVm });
                 col.Children.Add(new LauncherHeader { Width = 400, Height = 48, DataContext = launchVmStop });

--- a/Preview/PreviewStubs.cs
+++ b/Preview/PreviewStubs.cs
@@ -339,3 +339,8 @@ internal sealed class StubGameWindowService : IGameWindowService
     public void SetWindowIcon(string exePath) { }
     public void FocusWindow() { }
 }
+
+internal sealed class StubDotakeysProfileService : IDotakeysProfileService
+{
+    public bool PrepareProfile(ulong steamId32) => true;
+}

--- a/Services/CfgGenerator.cs
+++ b/Services/CfgGenerator.cs
@@ -15,6 +15,12 @@ public static class CfgGenerator
     private const string PresetCfgFileName = "d2c_preset.cfg";
 
     /// <summary>
+    /// Server-managed immutable cfg, downloaded automatically into the game cfg folder.
+    /// The launcher always execs it; the engine silently skips it if the file is absent.
+    /// </summary>
+    public const string ImmutableServerCfgArg = "+exec d2c_preset_config_imm.cfg";
+
+    /// <summary>
     /// Preset cvars enforced on every launch. Not user-configurable.
     /// Exec'd after config.cfg so they always take effect.
     /// </summary>

--- a/Services/DotakeysProfileService.cs
+++ b/Services/DotakeysProfileService.cs
@@ -1,0 +1,217 @@
+using System;
+using System.IO;
+using System.Runtime.Versioning;
+using System.Text;
+using System.Text.RegularExpressions;
+using Microsoft.Win32;
+using d2c_launcher.Util;
+
+namespace d2c_launcher.Services;
+
+/// <summary>
+/// Manages the Dotakeys keybind profile for Dotaclassic (App ID 570).
+///
+/// On first launch: copies dotakeys_personal.lst → dotakeys_684.lst (migration).
+/// Every launch: patches the ScreenshotSettings block to enforce the chatwheel action binding.
+/// Never modifies dotakeys_personal.lst after migration.
+/// </summary>
+[SupportedOSPlatform("windows")]
+public class DotakeysProfileService : IDotakeysProfileService
+{
+    private const string ProfileFileName = "dotakeys_684.lst";
+    private const string SourceFileName  = "dotakeys_personal.lst";
+    private const string DotaAppId       = "570";
+
+    private const string TargetAction      = "+chatwheel_hero";
+    private const string TargetDescription = "#DOTA_ChatWheel_HeroClassicPlus";
+
+    public bool PrepareProfile(ulong steamId32)
+    {
+        var cfgDir = ResolveProfileDirectory(steamId32);
+        if (cfgDir == null)
+        {
+            AppLog.Error("[DotakeysProfile] Cannot resolve Steam userdata cfg directory.");
+            return false;
+        }
+
+        var profilePath = Path.Combine(cfgDir, ProfileFileName);
+        var sourcePath  = Path.Combine(cfgDir, SourceFileName);
+
+        // ── One-time migration ─────────────────────────────────────────────────
+        if (!File.Exists(profilePath))
+        {
+            if (!File.Exists(sourcePath))
+            {
+                AppLog.Error($"[DotakeysProfile] Neither {ProfileFileName} nor {SourceFileName} found in: {cfgDir}");
+                return false;
+            }
+
+            try
+            {
+                File.Copy(sourcePath, profilePath, overwrite: false);
+                AppLog.Info($"[DotakeysProfile] Migrated {SourceFileName} → {ProfileFileName}");
+            }
+            catch (Exception ex)
+            {
+                AppLog.Error($"[DotakeysProfile] Failed to copy {SourceFileName} → {ProfileFileName}", ex);
+                return false;
+            }
+        }
+
+        // ── Per-launch patch ───────────────────────────────────────────────────
+        return PatchProfile(profilePath);
+    }
+
+    private static bool PatchProfile(string profilePath)
+    {
+        string content;
+        try
+        {
+            content = File.ReadAllText(profilePath, Encoding.UTF8);
+        }
+        catch (Exception ex)
+        {
+            AppLog.Error($"[DotakeysProfile] Failed to read {profilePath}", ex);
+            return false;
+        }
+
+        var (patched, changed) = ApplyScreenshotPatch(content);
+
+        if (!changed)
+        {
+            AppLog.Info("[DotakeysProfile] Already up-to-date, no write needed.");
+            return true;
+        }
+
+        // Atomic write: write to temp file, then replace the original
+        var tempPath = profilePath + ".launcher.tmp";
+        try
+        {
+            File.WriteAllText(tempPath, patched, new UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
+            File.Move(tempPath, profilePath, overwrite: true);
+            AppLog.Info("[DotakeysProfile] Patched ScreenshotSettings successfully.");
+            return true;
+        }
+        catch (Exception ex)
+        {
+            AppLog.Error("[DotakeysProfile] Failed to write patched profile.", ex);
+            try { File.Delete(tempPath); } catch { /* best-effort cleanup */ }
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// Finds the ScreenshotSettings block and replaces the Action and Description values
+    /// if they differ from the target values. Returns the (possibly modified) text and
+    /// a flag indicating whether anything actually changed.
+    /// </summary>
+    private static (string text, bool changed) ApplyScreenshotPatch(string content)
+    {
+        var blockRange = FindBlock(content, "ScreenshotSettings");
+        if (blockRange == null)
+        {
+            AppLog.Warn("[DotakeysProfile] ScreenshotSettings block not found — skipping patch.");
+            return (content, false);
+        }
+
+        var (blockStart, blockEnd) = blockRange.Value;
+        var blockText = content[blockStart..blockEnd];
+
+        var changed = false;
+        var patchedBlock = PatchKeyInBlock(blockText, "Action",      TargetAction,      ref changed);
+            patchedBlock = PatchKeyInBlock(patchedBlock, "Description", TargetDescription, ref changed);
+
+        if (!changed)
+            return (content, false);
+
+        return (string.Concat(content.AsSpan(0, blockStart), patchedBlock, content.AsSpan(blockEnd)), true);
+    }
+
+    /// <summary>
+    /// Returns the character range [start, end) of the block body delimited by the
+    /// outermost { … } that follows the <paramref name="blockName"/> header, or null
+    /// if the block is not found or is malformed.
+    /// </summary>
+    private static (int start, int end)? FindBlock(string content, string blockName)
+    {
+        var headerPattern = new Regex($@"""{Regex.Escape(blockName)}""\s*\{{", RegexOptions.IgnoreCase);
+        var m = headerPattern.Match(content);
+        if (!m.Success)
+            return null;
+
+        // The { character is the last char of the match
+        var braceStart = m.Index + m.Length - 1;
+
+        var depth = 0;
+        for (var i = braceStart; i < content.Length; i++)
+        {
+            if (content[i] == '{') depth++;
+            else if (content[i] == '}')
+            {
+                depth--;
+                if (depth == 0)
+                    return (braceStart, i + 1);
+            }
+        }
+
+        AppLog.Warn("[DotakeysProfile] ScreenshotSettings block has no matching closing brace.");
+        return null;
+    }
+
+    /// <summary>
+    /// Replaces the value of <paramref name="key"/> inside a VDF block snippet.
+    /// Sets <paramref name="changed"/> to true if the replacement was made.
+    /// Replaces only the first occurrence (VDF keys are unique within a block).
+    /// </summary>
+    private static string PatchKeyInBlock(string block, string key, string newValue, ref bool changed)
+    {
+        var pattern = new Regex($@"(""{Regex.Escape(key)}""\s+)""([^""]*)""");
+        var localChanged = false;
+        var result = pattern.Replace(block, m =>
+        {
+            if (string.Equals(m.Groups[2].Value, newValue, StringComparison.Ordinal))
+                return m.Value; // already correct
+
+            localChanged = true;
+            return $"{m.Groups[1].Value}\"{newValue}\"";
+        }, count: 1);
+
+        if (localChanged)
+            changed = true;
+
+        return result;
+    }
+
+    /// <summary>
+    /// Resolves the path to <c>Steam/userdata/&lt;steamId32&gt;/570/remote/cfg/</c>
+    /// using the Steam install path from the registry.
+    /// Returns null if the path cannot be determined or does not exist on disk.
+    /// </summary>
+    private static string? ResolveProfileDirectory(ulong steamId32)
+    {
+        try
+        {
+            using var key = Registry.CurrentUser.OpenSubKey(@"Software\Valve\Steam", false);
+            var steamPath = key?.GetValue("SteamPath")?.ToString();
+            if (string.IsNullOrEmpty(steamPath))
+            {
+                AppLog.Warn("[DotakeysProfile] SteamPath not found in registry.");
+                return null;
+            }
+
+            var cfgDir = Path.Combine(steamPath, "userdata", steamId32.ToString(), DotaAppId, "remote", "cfg");
+            if (!Directory.Exists(cfgDir))
+            {
+                AppLog.Warn($"[DotakeysProfile] Cfg directory does not exist: {cfgDir}");
+                return null;
+            }
+
+            return cfgDir;
+        }
+        catch (Exception ex)
+        {
+            AppLog.Error("[DotakeysProfile] Failed to resolve Steam cfg directory.", ex);
+            return null;
+        }
+    }
+}

--- a/Services/IDotakeysProfileService.cs
+++ b/Services/IDotakeysProfileService.cs
@@ -1,0 +1,12 @@
+namespace d2c_launcher.Services;
+
+public interface IDotakeysProfileService
+{
+    /// <summary>
+    /// Runs one-time migration (dotakeys_personal.lst → dotakeys_684.lst) if needed,
+    /// then patches the required ScreenshotSettings fields.
+    /// Returns <c>false</c> if the profile could not be prepared; the caller should log
+    /// and proceed — a missing/broken keybind profile must not block game launch.
+    /// </summary>
+    bool PrepareProfile(ulong steamId32);
+}

--- a/ViewModels/GameLaunchViewModel.cs
+++ b/ViewModels/GameLaunchViewModel.cs
@@ -25,7 +25,14 @@ public partial class GameLaunchViewModel : ViewModelBase, IDisposable
     private readonly IQueueSocketService _queueSocketService;
     private readonly INetConService _netConService;
     private readonly IGameWindowService _gameWindowService;
+    private readonly IDotakeysProfileService _dotakeysProfileService;
     private readonly DispatcherTimer _runStateTimer;
+
+    /// <summary>
+    /// Returns the Steam32 account ID of the currently logged-in user, or null if unknown.
+    /// Set by the parent ViewModel after construction.
+    /// </summary>
+    public Func<ulong?>? GetCurrentSteamId32 { get; set; }
 
     [ObservableProperty]
     private string? _gameDirectory;
@@ -77,7 +84,8 @@ public partial class GameLaunchViewModel : ViewModelBase, IDisposable
         IQueueSocketService queueSocketService,
         IBackendApiService backendApiService,
         INetConService netConService,
-        IGameWindowService gameWindowService)
+        IGameWindowService gameWindowService,
+        IDotakeysProfileService dotakeysProfileService)
     {
         _settingsStorage = settingsStorage;
         _launchSettingsStorage = launchSettingsStorage;
@@ -87,6 +95,7 @@ public partial class GameLaunchViewModel : ViewModelBase, IDisposable
         _queueSocketService = queueSocketService;
         _netConService = netConService;
         _gameWindowService = gameWindowService;
+        _dotakeysProfileService = dotakeysProfileService;
         var settings = settingsStorage.Get();
         _gameDirectory = settings.GameDirectory;
         _runState = GameRunState.None;
@@ -233,8 +242,16 @@ public partial class GameLaunchViewModel : ViewModelBase, IDisposable
             if (!string.IsNullOrEmpty(cliArgs)) parts.Add(cliArgs);
             if (presetArg != null) parts.Add(presetArg);
             if (execArg != null) parts.Add(execArg);
+            parts.Add(CfgGenerator.ImmutableServerCfgArg);
             if (!string.IsNullOrEmpty(launchOptions)) parts.Add(launchOptions);
             var arguments = string.Join(" ", parts);
+
+            // Ensure the Dotaclassic keybind profile is migrated and patched before launch
+            var steamId32 = GetCurrentSteamId32?.Invoke();
+            if (steamId32.HasValue)
+                _dotakeysProfileService.PrepareProfile(steamId32.Value);
+            else
+                AppLog.Warn("LaunchGame: Steam user unknown, skipping keybind profile patch.");
 
             AppLog.Info($"LaunchGame: starting {exePath} {arguments}");
             var process = Process.Start(new ProcessStartInfo

--- a/ViewModels/MainLauncherViewModel.cs
+++ b/ViewModels/MainLauncherViewModel.cs
@@ -122,7 +122,8 @@ public partial class MainLauncherViewModel : ViewModelBase, IDisposable
         ITriviaRepository triviaRepository,
         ITimerFactory timerFactory,
         INetConService netConService,
-        IGameWindowService gameWindowService)
+        IGameWindowService gameWindowService,
+        IDotakeysProfileService dotakeysProfileService)
     {
         _steamManager = steamManager;
         _settingsStorage = settingsStorage;
@@ -155,7 +156,8 @@ public partial class MainLauncherViewModel : ViewModelBase, IDisposable
         }
 
         // Create child ViewModels
-        Launch = new GameLaunchViewModel(settingsStorage, launchSettingsStorage, cvarProvider, videoProvider, queueSocketService, backendApiService, netConService, gameWindowService);
+        Launch = new GameLaunchViewModel(settingsStorage, launchSettingsStorage, cvarProvider, videoProvider, queueSocketService, backendApiService, netConService, gameWindowService, dotakeysProfileService);
+        Launch.GetCurrentSteamId32 = () => _steamManager.CurrentUser?.SteamId32;
         Queue = new QueueViewModel(queueSocketService, backendApiService, settingsStorage, triviaRepository, timerFactory);
         Room = new RoomViewModel(queueSocketService, backendApiService);
         Party = new PartyViewModel(queueSocketService, backendApiService);

--- a/ViewModels/MainWindowViewModel.cs
+++ b/ViewModels/MainWindowViewModel.cs
@@ -39,6 +39,7 @@ public partial class MainWindowViewModel : ViewModelBase
     private readonly ITimerFactory _timerFactory;
     private readonly INetConService _netConService;
     private readonly IGameWindowService _gameWindowService;
+    private readonly IDotakeysProfileService _dotakeysProfileService;
 
     /// <summary>Pending spectate match ID received before the Launcher state was entered.</summary>
     private int? _pendingSpectateMatchId;
@@ -97,7 +98,8 @@ public partial class MainWindowViewModel : ViewModelBase
         ITriviaRepository triviaRepository,
         ITimerFactory timerFactory,
         INetConService netConService,
-        IGameWindowService gameWindowService)
+        IGameWindowService gameWindowService,
+        IDotakeysProfileService dotakeysProfileService)
     {
         _steamManager = steamManager;
         _settingsStorage = settingsStorage;
@@ -120,6 +122,7 @@ public partial class MainWindowViewModel : ViewModelBase
         _timerFactory = timerFactory;
         _netConService = netConService;
         _gameWindowService = gameWindowService;
+        _dotakeysProfileService = dotakeysProfileService;
 
         // Eagerly prefetch the registry so it's cached by the time GameDownloadViewModel needs it.
         var initialGameDir = _settingsStorage.Get().GameDirectory;
@@ -321,7 +324,8 @@ public partial class MainWindowViewModel : ViewModelBase
         var vm = new MainLauncherViewModel(
             _steamManager, _settingsStorage, _launchSettingsStorage, _cvarProvider, _videoProvider,
             _backendApiService, _queueSocketService, _registryService, _chatViewModelFactory, _windowService,
-            _steamAuthApi, _uiDispatcher, _triviaRepository, _timerFactory, _netConService, _gameWindowService);
+            _steamAuthApi, _uiDispatcher, _triviaRepository, _timerFactory, _netConService, _gameWindowService,
+            _dotakeysProfileService);
         vm.OnGameDirectoryChanged = _ => Dispatcher.UIThread.Post(() => EnterState(AppStateMachine.OnGameDirChanged(AppState)));
         vm.RequestGameDirectoryChange = () => Dispatcher.UIThread.Post(() => EnterState(AppState.SelectGameDirectory));
         vm.OnDlcChanged = removedIds => Dispatcher.UIThread.Post(() =>


### PR DESCRIPTION
## Summary

- **DotakeysProfileService**: on first launch copies `dotakeys_personal.lst` → `dotakeys_684.lst` (migration); every launch patches `ScreenshotSettings` block (`Action = +chatwheel_hero`, `Description = #DOTA_ChatWheel_HeroClassicPlus`); atomic write via temp file + replace; logs all outcomes
- **Immutable server cfg**: always passes `+exec d2c_preset_config_imm.cfg` at launch — engine silently skips it when the file is absent
- `IDotakeysProfileService` registered as singleton; `GetCurrentSteamId32` delegate wired in `MainLauncherViewModel`; `StubDotakeysProfileService` added to preview

## Test plan

- [x] First launch (no `dotakeys_684.lst`): file is created as copy of `dotakeys_personal.lst`; log shows `migrated`
- [x] Re-launch: no copy, only patch enforced; log shows `already up-to-date` or `patched`
- [x] `dotakeys_personal.lst` unchanged after migration
- [x] Launch args contain `+exec d2c_preset_config_imm.cfg`
- [x] Neither dotakeys file exists: log shows error, launch proceeds normally

Closes #139

🤖 Generated with [Claude Code](https://claude.com/claude-code)