### PR TITLE
fix: always enable -override_vpk on game launch

### DIFF
--- a/ViewModels/GameLaunchViewModel.cs
+++ b/ViewModels/GameLaunchViewModel.cs
@@ -230,13 +230,7 @@ public partial class GameLaunchViewModel : ViewModelBase, IDisposable
             var presetArg = CfgGenerator.WritePreset(GameDirectory, _cvarProvider.GetPresetCvars());
             var execArg = CfgGenerator.Generate(launchSettings, GameDirectory);
 
-            // If any optional DLC is installed, the engine needs -override_vpk to load custom VPKs.
-            var appSettings = _settingsStorage.Get();
-            var hasOptionalDlcInstalled = appSettings.SelectedDlcIds?.Count > 0
-                && appSettings.InstalledPackageIds != null
-                && appSettings.SelectedDlcIds.Exists(id => appSettings.InstalledPackageIds.Contains(id));
-            if (hasOptionalDlcInstalled)
-                cliArgs = string.IsNullOrEmpty(cliArgs) ? "-override_vpk" : $"{cliArgs} -override_vpk";
+            cliArgs = string.IsNullOrEmpty(cliArgs) ? "-override_vpk" : $"{cliArgs} -override_vpk";
 
             var parts = new System.Collections.Generic.List<string>();
             if (!string.IsNullOrEmpty(cliArgs)) parts.Add(cliArgs);


### PR DESCRIPTION
## Summary
- Removes the DLC-conditional logic for `-override_vpk` (the flag was already hardcoded to `true` but left behind commented dead code)
- `-override_vpk` is now unconditionally appended to the launch arguments on every game start

## Test plan
- [ ] Launch game — verify `-override_vpk` is present in process arguments
- [ ] No regression in normal launch flow

Closes #144