### PR TITLE
fix: use canAbandon from server game state to show abandon button

### DIFF
--- a/Services/QueueSocketService.cs
+++ b/Services/QueueSocketService.cs
@@ -208,7 +208,8 @@ public sealed record PlayerRoomStateMessage(
     [property: JsonPropertyName("entries")] PlayerRoomEntry[] Entries);
 
 public sealed record PlayerGameStateMessage(
-    [property: JsonPropertyName("serverUrl")] string ServerUrl);
+    [property: JsonPropertyName("serverUrl")] string ServerUrl,
+    [property: JsonPropertyName("canAbandon")] bool? CanAbandon);
 
 public sealed record PlayerPartyInvitationsMessage(
     [property: JsonPropertyName("invitations")] PartyInviteReceivedMessage[] Invitations);

--- a/ViewModels/GameLaunchViewModel.cs
+++ b/ViewModels/GameLaunchViewModel.cs
@@ -43,6 +43,9 @@ public partial class GameLaunchViewModel : ViewModelBase, IDisposable
     [ObservableProperty]
     private string? _serverUrl;
 
+    [ObservableProperty]
+    private bool? _canAbandonFromServer;
+
     public bool HasServerUrl => !string.IsNullOrEmpty(ServerUrl);
 
     partial void OnServerUrlChanged(string? value) => OnPropertyChanged(nameof(HasServerUrl));
@@ -129,6 +132,7 @@ public partial class GameLaunchViewModel : ViewModelBase, IDisposable
     {
         var serverUrl = msg?.ServerUrl;
         ServerUrl = serverUrl;
+        CanAbandonFromServer = msg?.CanAbandon;
 
         if (_serverUrlTracker.ShouldConnect(serverUrl) && _settingsStorage.Get().AutoConnectToGame)
         {

--- a/ViewModels/MainLauncherViewModel.cs
+++ b/ViewModels/MainLauncherViewModel.cs
@@ -80,19 +80,8 @@ public partial class MainLauncherViewModel : ViewModelBase, IDisposable
     [ObservableProperty]
     private bool _isAbandonConfirmOpen;
 
-    /// <summary>True when a game server URL is active AND the mode allows abandoning (not unranked 5x5 or highroom).</summary>
-    public bool CanAbandonGame
-    {
-        get
-        {
-            if (!Launch.HasServerUrl) return false;
-            var mode = Room.RoomMode;
-            if (mode == null) return false; // no room state = spectating or no active match
-            var modeId = (int)mode.Value;
-            // Unranked 5x5 (1) and Highroom (8) do not allow abandoning
-            return modeId != 1 && modeId != 8;
-        }
-    }
+    /// <summary>True when the server reports an active game that can be abandoned.</summary>
+    public bool CanAbandonGame => Launch.HasServerUrl && (Launch.CanAbandonFromServer ?? false);
 
     [ObservableProperty]
     private int _onlineInGame;
@@ -191,12 +180,7 @@ public partial class MainLauncherViewModel : ViewModelBase, IDisposable
 
         Launch.PropertyChanged += (_, e) =>
         {
-            if (e.PropertyName == nameof(GameLaunchViewModel.HasServerUrl))
-                OnPropertyChanged(nameof(CanAbandonGame));
-        };
-        Room.PropertyChanged += (_, e) =>
-        {
-            if (e.PropertyName == nameof(RoomViewModel.RoomMode))
+            if (e.PropertyName is nameof(GameLaunchViewModel.HasServerUrl) or nameof(GameLaunchViewModel.CanAbandonFromServer))
                 OnPropertyChanged(nameof(CanAbandonGame));
         };
 


### PR DESCRIPTION
## Summary
- Added `CanAbandon` (bool?) field to `PlayerGameStateMessage` socket record
- `GameLaunchViewModel` now tracks `CanAbandonFromServer` and updates it on every game state message
- `CanAbandonGame` in `MainLauncherViewModel` replaced the hardcoded mode ID denylist (1, 8) with `Launch.HasServerUrl && (Launch.CanAbandonFromServer ?? false)`
- Mid-game updates to `canAbandon` correctly re-evaluate the property via the `CanAbandonFromServer` change listener

Closes #152