### PR TITLE
fix: chat window getting stuck in loading state

### DIFF
--- a/ViewModels/ChatViewModel.cs
+++ b/ViewModels/ChatViewModel.cs
@@ -212,12 +212,15 @@ public partial class ChatViewModel : ViewModelBase, IDisposable
     public async Task RefreshAsync()
     {
         _loadCts?.Cancel();
-        _loadCts = new CancellationTokenSource();
-        var ct = _loadCts.Token;
+        var cts = new CancellationTokenSource();
+        _loadCts = cts;
+        var ct = cts.Token;
+
+        bool IsLatest() => ReferenceEquals(_loadCts, cts);
 
         try
         {
-            _dispatcher.Post(() => IsLoading = Messages.Count == 0);
+            _dispatcher.Post(() => { if (IsLatest()) IsLoading = Messages.Count == 0; });
 
             var data = await _backendApiService.GetChatMessagesAsync(
                 _threadId, MessageLimit, ct).ConfigureAwait(false);
@@ -233,15 +236,25 @@ public partial class ChatViewModel : ViewModelBase, IDisposable
                 if (ct.IsCancellationRequested) return;
                 ApplyMessages(grouped);
                 MessagesUpdated?.Invoke();
-                IsLoading = false;
             });
         }
         catch (OperationCanceledException) { }
         catch (Exception ex)
         {
             AppLog.Error($"Chat refresh failed: {ex.Message}", ex);
-            _dispatcher.Post(() => IsLoading = false);
         }
+        finally
+        {
+            _dispatcher.Post(() => { if (IsLatest()) IsLoading = false; });
+        }
+    }
+
+    /// <summary>Triggers a refresh if the message list is empty. Call on user-driven events (e.g. tab switch)
+    /// to recover from a failed initial load.</summary>
+    public void RefreshIfEmpty()
+    {
+        if (Messages.Count == 0)
+            _ = RefreshAsync();
     }
 
     public void SetReplyTarget(ChatMessageView msg)

--- a/ViewModels/MainLauncherViewModel.cs
+++ b/ViewModels/MainLauncherViewModel.cs
@@ -301,6 +301,7 @@ public partial class MainLauncherViewModel : ViewModelBase, IDisposable
         OnPropertyChanged(nameof(IsProfileTabActive));
         if (value == LauncherTab.Streams)
             Streams.RequestRefresh();
+        Chat.RefreshIfEmpty();
     }
 
     // ── Tab navigation ────────────────────────────────────────────────────────

--- a/memory-bank/activeContext.md
+++ b/memory-bank/activeContext.md
@@ -38,6 +38,7 @@ All major features are shipped. The launcher is in maintenance/polish mode. Work
 | Issue | What was done |
 |-------|--------------|
 | #148 | Streams tab — `StreamsViewModel` polls `/v1/stats/twitch` every 60s; `StreamsPanel` shows Twitch-like preview cards (thumbnail, title, viewer count, streamer name, clickable link); tab only visible in header when `HasStreams` is true; auto-navigates to Play if streams disappear while tab is active |
+| #154 | Chat stuck in loading state — `ChatViewModel.RefreshAsync` now clears `IsLoading` in `finally` (only when the call is still the latest), fixing leaks on cancel paths; added `RefreshIfEmpty()` called from `MainLauncherViewModel.OnActiveTabChanged` so tab switches retry a failed initial load |
 
 ## Next Steps / Open Issues
 


### PR DESCRIPTION
## Summary
- `ChatViewModel.RefreshAsync` leaked `IsLoading = true` on cancellation paths; moved the reset into `finally`, guarded by an `IsLatest()` check so superseded loads don't clobber a newer one's state.
- Added `ChatViewModel.RefreshIfEmpty()`, called from `MainLauncherViewModel.OnActiveTabChanged`, so switching tabs retries a failed initial load (matches the reported UX expectation).

## Test plan
- [x] `dotnet build` clean
- [x] `dotnet test` — 295 passed
- [x] Manual: start with backend unreachable → verify IsLoading clears; reconnect → switch tab → chat populates

Closes #154