### PR TITLE
fix: restore minimized Dota window when bringing to foreground

### DIFF
--- a/Integration/DotaConsoleConnector.cs
+++ b/Integration/DotaConsoleConnector.cs
@@ -77,11 +77,12 @@ public static class DotaConsoleConnector
     public static void FocusWindow()
     {
         var hwnd = WinApi.FindWindowA(null, DotaWindowTitle);
-        if (hwnd != IntPtr.Zero)
-        {
-            WinApi.ShowWindow(hwnd, WinApi.SW_RESTORE);
-            WinApi.SetForegroundWindow(hwnd);
-        }
+        if (hwnd == IntPtr.Zero)
+            return;
+
+        WinApi.ShowWindow(hwnd, WinApi.SW_RESTORE);
+        if (!WinApi.SetForegroundWindow(hwnd))
+            AppLog.Info("DotaConsoleConnector.FocusWindow: SetForegroundWindow returned false");
     }
 
     /// <summary>Sends a console command string to the Dota 2 window. Returns false if the window was not found.</summary>

--- a/Integration/DotaConsoleConnector.cs
+++ b/Integration/DotaConsoleConnector.cs
@@ -78,7 +78,10 @@ public static class DotaConsoleConnector
     {
         var hwnd = WinApi.FindWindowA(null, DotaWindowTitle);
         if (hwnd != IntPtr.Zero)
+        {
+            WinApi.ShowWindow(hwnd, WinApi.SW_RESTORE);
             WinApi.SetForegroundWindow(hwnd);
+        }
     }
 
     /// <summary>Sends a console command string to the Dota 2 window. Returns false if the window was not found.</summary>

--- a/Integration/SocketEventCoordinator.cs
+++ b/Integration/SocketEventCoordinator.cs
@@ -32,6 +32,7 @@ public sealed class SocketEventCoordinator : IDisposable
     private readonly Func<MatchmakingMode, string> _getModeName;
 
     private string? _lastServerUrl;
+    private bool _playerRoomFoundSeen;
 
     public SocketEventCoordinator(
         IQueueSocketService queueSocketService,
@@ -65,6 +66,7 @@ public sealed class SocketEventCoordinator : IDisposable
 
     private void OnPlayerRoomFound(PlayerRoomStateMessage? _)
     {
+        _playerRoomFoundSeen = true;
         SoundPlayer.Play("match_found.mp3");
         Dispatcher.UIThread.Post(_windowService.ShowAndActivate);
     }
@@ -75,7 +77,15 @@ public sealed class SocketEventCoordinator : IDisposable
         if (string.IsNullOrEmpty(serverUrl) || serverUrl == _lastServerUrl)
             return;
 
+        var wasNull = _lastServerUrl == null;
         _lastServerUrl = serverUrl;
+
+        // Suppress sound and window pop-up on the first update after a launcher restart:
+        // a null→url transition without a preceding PlayerRoomFound means the game was
+        // already running when we connected — not a newly found match.
+        if (wasNull && !_playerRoomFoundSeen)
+            return;
+
         SoundPlayer.Play("ready_check_no_focus.wav");
         Dispatcher.UIThread.Post(_windowService.ShowAndActivate);
     }

--- a/Integration/SocketEventCoordinator.cs
+++ b/Integration/SocketEventCoordinator.cs
@@ -32,7 +32,6 @@ public sealed class SocketEventCoordinator : IDisposable
     private readonly Func<MatchmakingMode, string> _getModeName;
 
     private string? _lastServerUrl;
-    private bool _playerRoomFoundSeen;
 
     public SocketEventCoordinator(
         IQueueSocketService queueSocketService,
@@ -66,7 +65,6 @@ public sealed class SocketEventCoordinator : IDisposable
 
     private void OnPlayerRoomFound(PlayerRoomStateMessage? _)
     {
-        _playerRoomFoundSeen = true;
         SoundPlayer.Play("match_found.mp3");
         Dispatcher.UIThread.Post(_windowService.ShowAndActivate);
     }
@@ -77,16 +75,7 @@ public sealed class SocketEventCoordinator : IDisposable
         if (string.IsNullOrEmpty(serverUrl) || serverUrl == _lastServerUrl)
             return;
 
-        var wasNull = _lastServerUrl == null;
         _lastServerUrl = serverUrl;
-
-        // Suppress sound and window pop-up on the first update after a launcher restart:
-        // a null→url transition without a preceding PlayerRoomFound means the game was
-        // already running when we connected — not a newly found match.
-        if (wasNull && !_playerRoomFoundSeen)
-            return;
-
-        SoundPlayer.Play("ready_check_no_focus.wav");
         Dispatcher.UIThread.Post(_windowService.ShowAndActivate);
     }
 

--- a/Util/WinApi.cs
+++ b/Util/WinApi.cs
@@ -30,6 +30,7 @@ internal static class WinApi
     public const int SW_RESTORE = 9;
 
     [DllImport("user32.dll")]
+    [return: MarshalAs(UnmanagedType.Bool)]
     public static extern bool ShowWindow(IntPtr hWnd, int nCmdShow);
 
     // --- IPropertyStore COM interop for taskbar icon control ---

--- a/Util/WinApi.cs
+++ b/Util/WinApi.cs
@@ -27,6 +27,11 @@ internal static class WinApi
     [return: MarshalAs(UnmanagedType.Bool)]
     public static extern bool SetForegroundWindow(IntPtr hWnd);
 
+    public const int SW_RESTORE = 9;
+
+    [DllImport("user32.dll")]
+    public static extern bool ShowWindow(IntPtr hWnd, int nCmdShow);
+
     // --- IPropertyStore COM interop for taskbar icon control ---
 
     [DllImport("shell32.dll", SetLastError = true)]

--- a/ViewModels/GameLaunchViewModel.cs
+++ b/ViewModels/GameLaunchViewModel.cs
@@ -290,7 +290,7 @@ public partial class GameLaunchViewModel : ViewModelBase, IDisposable
     {
         _connectCts?.Cancel();
         _connectCts = new CancellationTokenSource();
-        _ = ConnectToGameAsync(_connectCts.Token);
+        _ = ConnectToGameAsync(_connectCts.Token, playSound: true);
     }
 
     /// <summary>
@@ -344,7 +344,7 @@ public partial class GameLaunchViewModel : ViewModelBase, IDisposable
         }
     }
 
-    private async Task ConnectToGameAsync(CancellationToken ct)
+    private async Task ConnectToGameAsync(CancellationToken ct, bool playSound = false)
     {
         var url = ServerUrl;
         if (string.IsNullOrEmpty(url))
@@ -376,6 +376,7 @@ public partial class GameLaunchViewModel : ViewModelBase, IDisposable
             }
 
             AppLog.Info($"ConnectToGame: launching our Dota with +connect {url}");
+            if (playSound) SoundPlayer.Play("ready_check_no_focus.wav");
             LaunchGame($"+connect {url}");
             return;
         }
@@ -414,6 +415,7 @@ public partial class GameLaunchViewModel : ViewModelBase, IDisposable
         }
 
         AppLog.Info($"ConnectToGame: sending 'connect {url}'");
+        if (playSound) SoundPlayer.Play("ready_check_no_focus.wav");
         await _netConService.SendCommandAsync($"connect {url}").ConfigureAwait(false);
         _gameWindowService.FocusWindow();
     }


### PR DESCRIPTION
## Summary
- `FocusWindow()` now calls `ShowWindow(SW_RESTORE)` before `SetForegroundWindow`
- Fixes the case where Dota is minimized when auto-connect fires — without `ShowWindow`, the window stays minimized even though `SetForegroundWindow` is called
- Follows the standard Windows bring-to-front pattern

## Test plan
- [x] Launch Dota, minimize it, then queue and accept a match — Dota should unminimize and come to front
- [x] Launch Dota, leave it in the background — still comes to front on connect

Closes #155