### PR TITLE
fix: restore SSD scan detection

### DIFF
--- a/Services/LocalManifestService.cs
+++ b/Services/LocalManifestService.cs
@@ -24,14 +24,14 @@ public class LocalManifestService : ILocalManifestService
         var files = new GameManifestFile[allFiles.Length];
         var done = 0;
 
-        // Load the hash cache — lets us skip re-hashing files whose size and mtime
+        // Load the hash cache - lets us skip re-hashing files whose size and mtime
         // haven't changed since the last scan (critical on HDD where reads are slow).
         var cache = LocalManifestCache.Load();
         var cacheUpdates = new ConcurrentDictionary<string, LocalManifestCacheEntry>(StringComparer.OrdinalIgnoreCase);
 
         // Use sequential I/O for HDD (avoids seek-head thrashing) and parallel for SSD.
         var parallelism = GetOptimalParallelism(gameDirectory);
-        var driveLabel = parallelism == 1 ? "HDD/unknown (sequential)" : $"SSD (parallel ×{parallelism})";
+        var driveLabel = parallelism == 1 ? "HDD/unknown (sequential)" : $"SSD (parallel x{parallelism})";
         AppLog.Info($"[Scan] {allFiles.Length} files, cache entries: {cache.Count}, drive: {driveLabel}");
 
         await Parallel.ForEachAsync(
@@ -48,12 +48,12 @@ public class LocalManifestService : ILocalManifestService
                     entry.Size == file.Length &&
                     entry.LastWriteUtcTicks == file.LastWriteTimeUtc.Ticks)
                 {
-                    // Cache hit — file is unchanged, reuse stored hash without reading the file.
+                    // Cache hit - file is unchanged, reuse stored hash without reading the file.
                     hash = entry.Hash;
                 }
                 else
                 {
-                    // Cache miss — hash the file and record the result for next time.
+                    // Cache miss - hash the file and record the result for next time.
                     hash = ComputeMd5(file.FullName);
                     cacheUpdates[relativePath] = new LocalManifestCacheEntry(
                         file.Length, file.LastWriteTimeUtc.Ticks, hash);
@@ -95,10 +95,13 @@ public class LocalManifestService : ILocalManifestService
     /// <summary>
     /// Returns the ideal <see cref="ParallelOptions.MaxDegreeOfParallelism"/> for reading
     /// files under <paramref name="gameDirectory"/>.
-    /// Detects whether the drive is an SSD via WMI MSFT_PhysicalDisk.MediaType:
-    ///   Win32_DiskDrive.Index maps to MSFT_PhysicalDisk.DeviceId
-    ///   4 = SSD → parallel reads (CPU-bound MD5 benefits from concurrency)
-    ///   3 = HDD or unknown → 1 (sequential, avoids disk-head thrashing)
+    /// Detects whether the drive is an SSD via WMI:
+    ///   First try the direct MSFT_PhysicalDisk.DeviceId == Win32_DiskDrive.Index mapping
+    ///   (works on the common single-node provider used by most desktops).
+    ///   If that fails, fall back to MSFT_StorageNodeToPhysicalDisk.DiskNumber and
+    ///   the associated MSFT_PhysicalDisk.MediaType.
+    ///   4 = SSD -> parallel reads (CPU-bound MD5 benefits from concurrency)
+    ///   3 = HDD or unknown -> 1 (sequential, avoids disk-head thrashing)
     /// Falls back to 1 on any WMI failure so HDD users are always protected.
     /// </summary>
     private static int GetOptimalParallelism(string gameDirectory)
@@ -110,7 +113,7 @@ public class LocalManifestService : ILocalManifestService
 
             var driveLetter = pathRoot.TrimEnd('\\', '/'); // e.g. "C:"
 
-            // Step 1: logical disk → disk partition
+            // Step 1: logical disk -> disk partition
             using var lpSearcher = new ManagementObjectSearcher(
                 "root\\CIMV2",
                 $"ASSOCIATORS OF {{Win32_LogicalDisk.DeviceID='{driveLetter}'}} " +
@@ -121,7 +124,7 @@ public class LocalManifestService : ILocalManifestService
                 var partId = partition["DeviceID"]?.ToString();
                 if (partId == null) continue;
 
-                // Step 2: disk partition → physical disk drive
+                // Step 2: disk partition -> physical disk drive
                 using var dpSearcher = new ManagementObjectSearcher(
                     "root\\CIMV2",
                     $"ASSOCIATORS OF {{Win32_DiskPartition.DeviceID='{partId}'}} " +
@@ -129,32 +132,23 @@ public class LocalManifestService : ILocalManifestService
 
                 foreach (ManagementObject disk in dpSearcher.Get())
                 {
-                    if (!TryGetDiskIndex(disk, out var diskNum))
+                    if (!TryGetDiskIndex(disk, out var diskNumber))
                         continue;
 
-                    // Step 3: query MSFT_PhysicalDisk for MediaType
-                    var scope = new ManagementScope(@"\\.\root\Microsoft\Windows\Storage");
-                    scope.Connect();
-                    using var pdSearcher = new ManagementObjectSearcher(
-                        scope,
-                        new ObjectQuery(
-                            $"SELECT DeviceId, MediaType FROM MSFT_PhysicalDisk WHERE DeviceId = '{diskNum}'"));
+                    if (!TryGetPhysicalDiskMediaType(diskNumber, out var mediaType))
+                        continue;
 
-                    foreach (ManagementObject physDisk in pdSearcher.Get())
-                    {
-                        var mediaType = physDisk["MediaType"] != null
-                            ? Convert.ToInt32(physDisk["MediaType"])
-                            : 0;
-
-                        // MediaType 4 = SSD; anything else (3=HDD, 0=Unspecified) → sequential.
-                        return mediaType == 4
-                            ? Math.Min(Environment.ProcessorCount, 8)
-                            : 1;
-                    }
+                    // MediaType 4 = SSD; anything else (3=HDD, 0=Unspecified) -> sequential.
+                    return mediaType == 4
+                        ? Math.Min(Environment.ProcessorCount, 8)
+                        : 1;
                 }
             }
         }
-        catch { /* WMI unavailable or failed — fall through to safe default */ }
+        catch
+        {
+            // WMI unavailable or failed -> fall through to the safe default.
+        }
 
         return 1; // Sequential: safe for HDD, acceptable for SSD
     }
@@ -171,5 +165,63 @@ public class LocalManifestService : ILocalManifestService
         var deviceId = disk["DeviceID"]?.ToString() ?? "";
         var digits = new string(deviceId.Where(char.IsDigit).ToArray());
         return int.TryParse(digits, out diskIndex);
+    }
+
+    private static bool TryGetPhysicalDiskMediaType(int diskNumber, out int mediaType)
+    {
+        mediaType = 0;
+
+        var scope = new ManagementScope(@"\\.\root\Microsoft\Windows\Storage");
+        scope.Connect();
+
+        if (TryGetPhysicalDiskMediaTypeByDeviceId(scope, diskNumber, out mediaType))
+            return true;
+
+        using var relationSearcher = new ManagementObjectSearcher(
+            scope,
+            new ObjectQuery(
+                $"SELECT DiskNumber, PhysicalDisk FROM MSFT_StorageNodeToPhysicalDisk WHERE DiskNumber = {diskNumber}"));
+
+        foreach (ManagementObject relation in relationSearcher.Get())
+        {
+            var physicalDiskPath = relation["PhysicalDisk"]?.ToString();
+            if (string.IsNullOrWhiteSpace(physicalDiskPath))
+                continue;
+
+            using var physicalDisk = new ManagementObject(scope, new ManagementPath(physicalDiskPath), null);
+            physicalDisk.Get();
+
+            mediaType = physicalDisk["MediaType"] != null
+                ? Convert.ToInt32(physicalDisk["MediaType"])
+                : 0;
+
+            return true;
+        }
+
+        return false;
+    }
+
+    private static bool TryGetPhysicalDiskMediaTypeByDeviceId(
+        ManagementScope scope,
+        int diskNumber,
+        out int mediaType)
+    {
+        mediaType = 0;
+
+        using var physicalDiskSearcher = new ManagementObjectSearcher(
+            scope,
+            new ObjectQuery(
+                $"SELECT DeviceId, MediaType FROM MSFT_PhysicalDisk WHERE DeviceId = '{diskNumber}'"));
+
+        foreach (ManagementObject physicalDisk in physicalDiskSearcher.Get())
+        {
+            mediaType = physicalDisk["MediaType"] != null
+                ? Convert.ToInt32(physicalDisk["MediaType"])
+                : 0;
+
+            return true;
+        }
+
+        return false;
     }
 }

--- a/Services/LocalManifestService.cs
+++ b/Services/LocalManifestService.cs
@@ -96,6 +96,7 @@ public class LocalManifestService : ILocalManifestService
     /// Returns the ideal <see cref="ParallelOptions.MaxDegreeOfParallelism"/> for reading
     /// files under <paramref name="gameDirectory"/>.
     /// Detects whether the drive is an SSD via WMI MSFT_PhysicalDisk.MediaType:
+    ///   Win32_DiskDrive.Index maps to MSFT_PhysicalDisk.DeviceId
     ///   4 = SSD → parallel reads (CPU-bound MD5 benefits from concurrency)
     ///   3 = HDD or unknown → 1 (sequential, avoids disk-head thrashing)
     /// Falls back to 1 on any WMI failure so HDD users are always protected.
@@ -128,17 +129,16 @@ public class LocalManifestService : ILocalManifestService
 
                 foreach (ManagementObject disk in dpSearcher.Get())
                 {
-                    // DeviceID looks like "\\.\PHYSICALDRIVE0" — extract the trailing number.
-                    var deviceId = disk["DeviceID"]?.ToString() ?? "";
-                    var numStr = new string(deviceId.Where(char.IsDigit).ToArray());
-                    if (!int.TryParse(numStr, out var diskNum)) continue;
+                    if (!TryGetDiskIndex(disk, out var diskNum))
+                        continue;
 
                     // Step 3: query MSFT_PhysicalDisk for MediaType
                     var scope = new ManagementScope(@"\\.\root\Microsoft\Windows\Storage");
                     scope.Connect();
                     using var pdSearcher = new ManagementObjectSearcher(
                         scope,
-                        new ObjectQuery($"SELECT MediaType FROM MSFT_PhysicalDisk WHERE Number = {diskNum}"));
+                        new ObjectQuery(
+                            $"SELECT DeviceId, MediaType FROM MSFT_PhysicalDisk WHERE DeviceId = '{diskNum}'"));
 
                     foreach (ManagementObject physDisk in pdSearcher.Get())
                     {
@@ -157,5 +157,19 @@ public class LocalManifestService : ILocalManifestService
         catch { /* WMI unavailable or failed — fall through to safe default */ }
 
         return 1; // Sequential: safe for HDD, acceptable for SSD
+    }
+
+    private static bool TryGetDiskIndex(ManagementObject disk, out int diskIndex)
+    {
+        if (disk["Index"] != null)
+        {
+            diskIndex = Convert.ToInt32(disk["Index"]);
+            return true;
+        }
+
+        // Older APIs expose the physical drive number only via DeviceID ("\\.\PHYSICALDRIVE2").
+        var deviceId = disk["DeviceID"]?.ToString() ?? "";
+        var digits = new string(deviceId.Where(char.IsDigit).ToArray());
+        return int.TryParse(digits, out diskIndex);
     }
 }

--- a/memory-bank/activeContext.md
+++ b/memory-bank/activeContext.md
@@ -39,6 +39,7 @@ Repository AI workflow files now use a shared `.agents/` layout. `.agents/comman
 
 | Issue | What was done |
 |-------|--------------|
+| #159 | Fixed local scan drive detection always falling back to `HDD/unknown` — `LocalManifestService` now maps `Win32_DiskDrive.Index` to `MSFT_PhysicalDisk.DeviceId` instead of querying non-existent `MSFT_PhysicalDisk.Number`; SSD installs can use parallel hashing again |
 | #148 | Streams tab — `StreamsViewModel` polls `/v1/stats/twitch` every 60s; `StreamsPanel` shows Twitch-like preview cards (thumbnail, title, viewer count, streamer name, clickable link); tab only visible in header when `HasStreams` is true; auto-navigates to Play if streams disappear while tab is active |
 | #154 | Chat stuck in loading state — `ChatViewModel.RefreshAsync` now clears `IsLoading` in `finally` (only when the call is still the latest), fixing leaks on cancel paths; added `RefreshIfEmpty()` called from `MainLauncherViewModel.OnActiveTabChanged` so tab switches retry a failed initial load |
 | #155 | Matchmaking Windows toasts — hidden launcher now shows actionable native toasts for party invites and ready checks; toast buttons route through `d2c://party-invite/...` and `d2c://ready-check/...`; `WindowService` preserves `WindowShown` after eager visibility updates |

--- a/memory-bank/activeContext.md
+++ b/memory-bank/activeContext.md
@@ -39,7 +39,7 @@ Repository AI workflow files now use a shared `.agents/` layout. `.agents/comman
 
 | Issue | What was done |
 |-------|--------------|
-| #159 | Fixed local scan drive detection always falling back to `HDD/unknown` — `LocalManifestService` now maps `Win32_DiskDrive.Index` to `MSFT_PhysicalDisk.DeviceId` instead of querying non-existent `MSFT_PhysicalDisk.Number`; SSD installs can use parallel hashing again |
+| #159 | Fixed local scan drive detection always falling back to `HDD/unknown` — `LocalManifestService` now uses a hybrid lookup: first `MSFT_PhysicalDisk.DeviceId == Win32_DiskDrive.Index` (works on common desktop providers), then `MSFT_StorageNodeToPhysicalDisk.DiskNumber` as a fallback before reading `MSFT_PhysicalDisk.MediaType`; SSD installs can use parallel hashing again on the machines we tested |
 | #148 | Streams tab — `StreamsViewModel` polls `/v1/stats/twitch` every 60s; `StreamsPanel` shows Twitch-like preview cards (thumbnail, title, viewer count, streamer name, clickable link); tab only visible in header when `HasStreams` is true; auto-navigates to Play if streams disappear while tab is active |
 | #154 | Chat stuck in loading state — `ChatViewModel.RefreshAsync` now clears `IsLoading` in `finally` (only when the call is still the latest), fixing leaks on cancel paths; added `RefreshIfEmpty()` called from `MainLauncherViewModel.OnActiveTabChanged` so tab switches retry a failed initial load |
 | #155 | Matchmaking Windows toasts — hidden launcher now shows actionable native toasts for party invites and ready checks; toast buttons route through `d2c://party-invite/...` and `d2c://ready-check/...`; `WindowService` preserves `WindowShown` after eager visibility updates |

--- a/memory-bank/docs/game-update-manifest.md
+++ b/memory-bank/docs/game-update-manifest.md
@@ -130,7 +130,9 @@ On each scan, if a file's `Length` and `LastWriteTimeUtc.Ticks` match the cached
 
 1. `Win32_LogicalDisk` → `Win32_DiskPartition` (via `Win32_LogicalDiskToPartition`)
 2. `Win32_DiskPartition` → `Win32_DiskDrive` (via `Win32_DiskDriveToDiskPartition`)
-3. `MSFT_PhysicalDisk.MediaType` where `DeviceId` matches `Win32_DiskDrive.Index`
+3. Try `MSFT_PhysicalDisk.MediaType` where `DeviceId` matches `Win32_DiskDrive.Index` (fast path that works on common desktop providers)
+4. If that fails, use `MSFT_StorageNodeToPhysicalDisk.DiskNumber` where it matches `Win32_DiskDrive.Index`
+5. Follow the associated `PhysicalDisk` reference and read `MSFT_PhysicalDisk.MediaType`
 
 | `MediaType` | Meaning | Parallelism |
 |-------------|---------|-------------|

--- a/memory-bank/docs/game-update-manifest.md
+++ b/memory-bank/docs/game-update-manifest.md
@@ -130,7 +130,7 @@ On each scan, if a file's `Length` and `LastWriteTimeUtc.Ticks` match the cached
 
 1. `Win32_LogicalDisk` → `Win32_DiskPartition` (via `Win32_LogicalDiskToPartition`)
 2. `Win32_DiskPartition` → `Win32_DiskDrive` (via `Win32_DiskDriveToDiskPartition`)
-3. `MSFT_PhysicalDisk.MediaType` where `Number` matches the physical drive index
+3. `MSFT_PhysicalDisk.MediaType` where `DeviceId` matches `Win32_DiskDrive.Index`
 
 | `MediaType` | Meaning | Parallelism |
 |-------------|---------|-------------|

--- a/memory-bank/progress.md
+++ b/memory-bank/progress.md
@@ -37,7 +37,7 @@
 | --------------------------------- | ------ | ---------------------------------- |
 | Game directory validation         | ✅ Done |                                    |
 | Game download / verify on launch  | ✅ Done | `GameDownloadView`, manifest diff, HTTP download |
-| HDD scan optimization (issue #9)  | ✅ Done | mtime+size hash cache + WMI SSD detection for parallelism |
+| HDD scan optimization (issue #9)  | ✅ Done | mtime+size hash cache + WMI SSD detection for parallelism; issue #159 fixed `MSFT_PhysicalDisk` lookup to use `DeviceId` so SSD installs no longer fall back to sequential `HDD/unknown` |
 | Scan duration metric to Faro (issue #10) | ✅ Done | `TrackEvent("scan_completed")` with `duration_ms` + `file_count` |
 | Redist install after verify (issue #6) | ✅ Done | `RedistInstallService` — runs `_CommonRedist` DirectX + vcredist silently once per game dir |
 | Game launch with Source 1 args    | ✅ Done |                                    |

--- a/memory-bank/progress.md
+++ b/memory-bank/progress.md
@@ -37,7 +37,7 @@
 | --------------------------------- | ------ | ---------------------------------- |
 | Game directory validation         | ✅ Done |                                    |
 | Game download / verify on launch  | ✅ Done | `GameDownloadView`, manifest diff, HTTP download |
-| HDD scan optimization (issue #9)  | ✅ Done | mtime+size hash cache + WMI SSD detection for parallelism; issue #159 fixed `MSFT_PhysicalDisk` lookup to use `DeviceId` so SSD installs no longer fall back to sequential `HDD/unknown` |
+| HDD scan optimization (issue #9)  | ✅ Done | mtime+size hash cache + WMI SSD detection for parallelism; issue #159 fixed the storage lookup with a hybrid strategy: `MSFT_PhysicalDisk.DeviceId == Win32_DiskDrive.Index` first, then `MSFT_StorageNodeToPhysicalDisk.DiskNumber` -> `MSFT_PhysicalDisk.MediaType` as a fallback, so tested SSD installs no longer fall back to sequential `HDD/unknown` |
 | Scan duration metric to Faro (issue #10) | ✅ Done | `TrackEvent("scan_completed")` with `duration_ms` + `file_count` |
 | Redist install after verify (issue #6) | ✅ Done | `RedistInstallService` — runs `_CommonRedist` DirectX + vcredist silently once per game dir |
 | Game launch with Source 1 args    | ✅ Done |                                    |


### PR DESCRIPTION
## Summary
- fix local manifest drive detection to query `MSFT_PhysicalDisk.DeviceId` instead of the non-existent `Number` field
- prefer `Win32_DiskDrive.Index` when mapping the logical game drive to the physical disk, with a `DeviceID` parsing fallback
- update memory-bank notes to document the corrected SSD/HDD detection path

## Verification
- `dotnet build`
- `dotnet test`

Closes #159
