### PR TITLE
fix: clear vulnerable package warnings

### DIFF
--- a/d2c-launcher.Tests/CvarSettingsProviderTests.cs
+++ b/d2c-launcher.Tests/CvarSettingsProviderTests.cs
@@ -67,8 +67,7 @@ public class CvarSettingsProviderTests : IDisposable
         _fileService.WriteLog.Clear();
         provider.Update(new CvarSettings { FpsMax = 144, Console = true });
 
-        var configWrite = _fileService.WriteLog.Find(w => w.Cvars.ContainsKey("fps_max"));
-        Assert.NotNull(configWrite);
+        var configWrite = Assert.Single(_fileService.WriteLog, w => w.Cvars.ContainsKey("fps_max"));
         Assert.Equal("144", configWrite.Cvars["fps_max"]);
         Assert.Equal("1", configWrite.Cvars["con_enable"]);
     }
@@ -83,8 +82,7 @@ public class CvarSettingsProviderTests : IDisposable
         _fileService.WriteLog.Clear();
         provider.Update(new CvarSettings { CameraDistance = 1200 });
 
-        var configWrite = _fileService.WriteLog.Find(w => w.Cvars.ContainsKey("cl_cloud_settings"));
-        Assert.NotNull(configWrite);
+        var configWrite = Assert.Single(_fileService.WriteLog, w => w.Cvars.ContainsKey("cl_cloud_settings"));
         Assert.DoesNotContain("dota_camera_distance", configWrite.Cvars.Keys);
     }
 
@@ -97,8 +95,7 @@ public class CvarSettingsProviderTests : IDisposable
         _fileService.WriteLog.Clear();
         provider.Update(new CvarSettings { AutoAttack = AutoAttackMode.Always });
 
-        var configWrite = _fileService.WriteLog.Find(w => w.Cvars.ContainsKey("cl_cloud_settings"));
-        Assert.NotNull(configWrite);
+        var configWrite = Assert.Single(_fileService.WriteLog, w => w.Cvars.ContainsKey("cl_cloud_settings"));
         Assert.Equal("1", configWrite.Cvars["dota_player_units_auto_attack"]);
         Assert.Equal("1", configWrite.Cvars["dota_player_units_auto_attack_after_spell"]);
     }

--- a/d2c-launcher.Tests/d2c-launcher.Tests.csproj
+++ b/d2c-launcher.Tests/d2c-launcher.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net10.0</TargetFramework>
+    <TargetFramework>net10.0-windows</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <IsPackable>false</IsPackable>

--- a/d2c-launcher.csproj
+++ b/d2c-launcher.csproj
@@ -44,6 +44,8 @@
     <PackageReference Include="SocketIOClient" Version="3.1.1" />
     <PackageReference Include="Steamworks.NET" Version="2024.8.0" />
     <PackageReference Include="System.Management" Version="9.0.0" />
+    <PackageReference Include="System.Drawing.Common" Version="4.7.2" />
+    <PackageReference Include="Tmds.DBus.Protocol" Version="0.21.3" />
     <PackageReference Include="Avalonia.Labs.Gif" Version="11.3.1" />
     <PackageReference Include="Microsoft.Toolkit.Uwp.Notifications" Version="7.1.2" />
     <PackageReference Include="Velopack" Version="0.0.1251" />

--- a/memory-bank/activeContext.md
+++ b/memory-bank/activeContext.md
@@ -39,7 +39,7 @@ Repository AI workflow files now use a shared `.agents/` layout. `.agents/comman
 
 | Issue | What was done |
 |-------|--------------|
-| #164 | Cleared build warnings from vulnerable transitive NuGet packages by pinning patched `System.Drawing.Common` 4.7.2 and `Tmds.DBus.Protocol` 0.21.3 in the launcher project; `dotnet build` now reports 0 warnings |
+| #164 | Cleared build/test warnings: pinned patched `System.Drawing.Common` 4.7.2 and `Tmds.DBus.Protocol` 0.21.3, targeted tests to `net10.0-windows`, and removed invalid xUnit value-tuple null asserts; `dotnet build` and `dotnet test d2c-launcher.Tests` now report 0 warnings |
 | #159 | Fixed local scan drive detection always falling back to `HDD/unknown` — `LocalManifestService` now uses a hybrid lookup: first `MSFT_PhysicalDisk.DeviceId == Win32_DiskDrive.Index` (works on common desktop providers), then `MSFT_StorageNodeToPhysicalDisk.DiskNumber` as a fallback before reading `MSFT_PhysicalDisk.MediaType`; SSD installs can use parallel hashing again on the machines we tested |
 | #148 | Streams tab — `StreamsViewModel` polls `/v1/stats/twitch` every 60s; `StreamsPanel` shows Twitch-like preview cards (thumbnail, title, viewer count, streamer name, clickable link); tab only visible in header when `HasStreams` is true; auto-navigates to Play if streams disappear while tab is active |
 | #154 | Chat stuck in loading state — `ChatViewModel.RefreshAsync` now clears `IsLoading` in `finally` (only when the call is still the latest), fixing leaks on cancel paths; added `RefreshIfEmpty()` called from `MainLauncherViewModel.OnActiveTabChanged` so tab switches retry a failed initial load |

--- a/memory-bank/activeContext.md
+++ b/memory-bank/activeContext.md
@@ -39,6 +39,7 @@ Repository AI workflow files now use a shared `.agents/` layout. `.agents/comman
 
 | Issue | What was done |
 |-------|--------------|
+| #164 | Cleared build warnings from vulnerable transitive NuGet packages by pinning patched `System.Drawing.Common` 4.7.2 and `Tmds.DBus.Protocol` 0.21.3 in the launcher project; `dotnet build` now reports 0 warnings |
 | #159 | Fixed local scan drive detection always falling back to `HDD/unknown` — `LocalManifestService` now uses a hybrid lookup: first `MSFT_PhysicalDisk.DeviceId == Win32_DiskDrive.Index` (works on common desktop providers), then `MSFT_StorageNodeToPhysicalDisk.DiskNumber` as a fallback before reading `MSFT_PhysicalDisk.MediaType`; SSD installs can use parallel hashing again on the machines we tested |
 | #148 | Streams tab — `StreamsViewModel` polls `/v1/stats/twitch` every 60s; `StreamsPanel` shows Twitch-like preview cards (thumbnail, title, viewer count, streamer name, clickable link); tab only visible in header when `HasStreams` is true; auto-navigates to Play if streams disappear while tab is active |
 | #154 | Chat stuck in loading state — `ChatViewModel.RefreshAsync` now clears `IsLoading` in `finally` (only when the call is still the latest), fixing leaks on cancel paths; added `RefreshIfEmpty()` called from `MainLauncherViewModel.OnActiveTabChanged` so tab switches retry a failed initial load |

--- a/memory-bank/progress.md
+++ b/memory-bank/progress.md
@@ -14,7 +14,7 @@
 | Settings persistence (launcher JSON)       | ✅ Done         | `%AppData%\d2c-launcher\launcher_settings.json` |
 | Application auto-updates                   | ✅ Done         | Velopack + GitHub Releases                      |
 | Hardware info logging + HWID               | ✅ Done         | `HardwareInfoService` logs hardware; HWID sent to backend via SteamBridge steam auth ticket endpoint |
-| Build warning cleanup (issue #164)         | ✅ Done         | Pinned patched transitive packages: `System.Drawing.Common` 4.7.2 for Windows toast dependency and `Tmds.DBus.Protocol` 0.21.3 for Avalonia FreeDesktop/X11 dependency; `dotnet build` reports 0 warnings |
+| Build warning cleanup (issue #164)         | ✅ Done         | Pinned patched transitive packages: `System.Drawing.Common` 4.7.2 for Windows toast dependency and `Tmds.DBus.Protocol` 0.21.3 for Avalonia FreeDesktop/X11 dependency; test project now targets `net10.0-windows` and uses warning-clean xUnit assertions; build and tests report 0 warnings |
 
 
 ### Matchmaking

--- a/memory-bank/progress.md
+++ b/memory-bank/progress.md
@@ -14,6 +14,7 @@
 | Settings persistence (launcher JSON)       | ✅ Done         | `%AppData%\d2c-launcher\launcher_settings.json` |
 | Application auto-updates                   | ✅ Done         | Velopack + GitHub Releases                      |
 | Hardware info logging + HWID               | ✅ Done         | `HardwareInfoService` logs hardware; HWID sent to backend via SteamBridge steam auth ticket endpoint |
+| Build warning cleanup (issue #164)         | ✅ Done         | Pinned patched transitive packages: `System.Drawing.Common` 4.7.2 for Windows toast dependency and `Tmds.DBus.Protocol` 0.21.3 for Avalonia FreeDesktop/X11 dependency; `dotnet build` reports 0 warnings |
 
 
 ### Matchmaking


### PR DESCRIPTION
## Summary
- pin patched transitive dependency versions for System.Drawing.Common and Tmds.DBus.Protocol
- update memory bank with issue #164 completion

## Verification
- dotnet list d2c-launcher.csproj package --vulnerable --include-transitive
- dotnet build
- dotnet test

Closes #164