### PR TITLE
feat: detect pending remote game updates (#167)

### DIFF
--- a/App.axaml.cs
+++ b/App.axaml.cs
@@ -133,6 +133,7 @@ public partial class App : Application
             services.AddSingleton<ILocalManifestService, LocalManifestService>();
             services.AddSingleton<IManifestDiffService, ManifestDiffService>();
             services.AddSingleton<IGameDownloadService, GameDownloadService>();
+            services.AddSingleton<IRemoteManifestService, RemoteManifestService>();
             services.AddSingleton<RedistInstallService>();
             services.AddSingleton<IContentRegistryService, ContentRegistryService>();
             services.AddSingleton<ITriviaRepository, LocalJsonTriviaRepository>();

--- a/Preview/PreviewRegistry.cs
+++ b/Preview/PreviewRegistry.cs
@@ -418,11 +418,11 @@ public static class PreviewRegistry
             ["GameDownload"] = () =>
             {
                 var vm = new GameDownloadViewModel(
-                    new StubContentRegistryService(),
                     new StubLocalManifestService(),
                     new StubManifestDiffService(),
                     new StubGameDownloadService(),
-                    new d2c_launcher.Services.RedistInstallService())
+                    new d2c_launcher.Services.RedistInstallService(),
+                    new StubRemoteManifestService())
                 {
                     GameDirectory = @"C:\fake\dotaclassic",
                     StatusText = "Загрузка (142/2381 файлов)",
@@ -435,11 +435,11 @@ public static class PreviewRegistry
             ["GameDownloadError"] = () =>
             {
                 var vm = new GameDownloadViewModel(
-                    new StubContentRegistryService(),
                     new StubLocalManifestService(),
                     new StubManifestDiffService(),
                     new StubGameDownloadService(),
-                    new d2c_launcher.Services.RedistInstallService())
+                    new d2c_launcher.Services.RedistInstallService(),
+                    new StubRemoteManifestService())
                 {
                     GameDirectory = @"C:\fake\dotaclassic",
                     StatusText = "Ошибка загрузки",

--- a/Preview/PreviewStubs.cs
+++ b/Preview/PreviewStubs.cs
@@ -50,6 +50,7 @@ internal sealed class StubQueueSocketService : IQueueSocketService
 #pragma warning restore CS0067
 
     public Task ConnectAsync(string token, CancellationToken cancellationToken = default) => Task.CompletedTask;
+    public Task ReconnectAsync(CancellationToken cancellationToken = default) => Task.CompletedTask;
     public Task DisconnectAsync(CancellationToken cancellationToken = default) => Task.CompletedTask;
     public Task EnterQueueAsync(MatchmakingMode[] modes, CancellationToken cancellationToken = default) => Task.CompletedTask;
     public Task LeaveAllQueuesAsync(CancellationToken cancellationToken = default) => Task.CompletedTask;

--- a/Preview/PreviewStubs.cs
+++ b/Preview/PreviewStubs.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using d2c_launcher.Api;
@@ -260,6 +261,38 @@ internal sealed class StubGameDownloadService : IGameDownloadService
         => Task.CompletedTask;
 }
 
+internal sealed class StubRemoteManifestService : IRemoteManifestService
+{
+    public Task<RemoteManifestSet> GetInstalledPackageManifestsAsync(
+        IReadOnlyCollection<string>? selectedDlcIds,
+        bool includeOptionalPackages = false,
+        bool forceRefreshRegistry = false,
+        CancellationToken cancellationToken = default)
+    {
+        var packages = new List<RemotePackageManifest>
+        {
+            new()
+            {
+                Package = new ContentPackage { Id = "base", Folder = "base", Name = "Dotaclassic", Optional = false },
+                Manifest = new GameManifest
+                {
+                    Files =
+                    [
+                        new GameManifestFile { Path = "dota.exe", Hash = "abc", Size = 123, Mode = "exact", PackageFolder = "base", PackageName = "Dotaclassic" }
+                    ]
+                }
+            }
+        };
+
+        return Task.FromResult(new RemoteManifestSet
+        {
+            Packages = packages,
+            CombinedManifest = new GameManifest { Files = [.. packages.SelectMany(p => p.Manifest.Files)] },
+            InstalledPackageIds = ["base"],
+        });
+    }
+}
+
 internal sealed class StubContentRegistryService : IContentRegistryService
 {
     private static readonly ContentRegistry StubRegistry = new()
@@ -383,6 +416,7 @@ internal sealed class StubToastNotificationService : IToastNotificationService
 {
     public void ShowMatchFound(string roomId) { }
     public void ShowPartyInvite(string inviteId, string inviterName) { }
+    public void ShowGameUpdateAvailable() { }
     public void Show(string title, string body, string? tag = null, string? launchArg = null) { }
     public void ShowGoQueue(string title, string body, int modeId) { }
 }

--- a/Resources/Locales/ru.json
+++ b/Resources/Locales/ru.json
@@ -307,6 +307,7 @@
     "noFolderAccess": "Нет доступа к выбранной папке. Выберите другую папку для установки.",
     "noFolderAccessTitle": "Нет доступа к папке",
     "noModeAccess": "Нет доступа к режиму",
+    "emptyPackageManifest": "Манифест пакета {name} пустой.",
     "connectingToServer": "Подключение к серверу...",
     "connectingToSteam": "Подключение к Steam...",
     "vsBots": "Против ботов",
@@ -409,6 +410,10 @@
       "title": "Доступно обновление игры",
       "body": "Новая версия Dotaclassic готова к установке. Откройте лаунчер, чтобы обновить игру.",
       "installButton": "Обновить"
+    },
+    "dev": {
+      "gameUpdateEnabled": "DEV: симулировано входящее обновление игры",
+      "gameUpdateDisabled": "DEV: симулированное обновление игры сброшено"
     }
   }
 }

--- a/Resources/Locales/ru.json
+++ b/Resources/Locales/ru.json
@@ -321,7 +321,13 @@
     "deletingDlcFiles": "Удаление файлов DLC...",
     "installingComponents": "Установка компонентов...",
     "gameFilesCorrupted": "Файлы игры повреждены или удалены антивирусом.",
-    "failedToLoadPackages": "Не удалось загрузить список пакетов с сервера."
+    "failedToLoadPackages": "Не удалось загрузить список пакетов с сервера.",
+    "update": "Обновить",
+    "updateGame": "ОБНОВИТЬ ИГРУ",
+    "updatePromptTitle": "Доступно обновление игры",
+    "updatePromptIdle": "Новая версия Dotaclassic готова к установке. Перед запуском нужно обновить файлы игры.",
+    "updatePromptRunning": "Новая версия Dotaclassic готова к установке. Установка закроет запущенную Dota.",
+    "installUpdate": "УСТАНОВИТЬ ОБНОВЛЕНИЕ"
   },
   "common": {
     "skip": "Пропустить",
@@ -398,6 +404,11 @@
     },
     "goQueue": {
       "enterQueueButton": "Искать игру"
+    },
+    "gameUpdate": {
+      "title": "Доступно обновление игры",
+      "body": "Новая версия Dotaclassic готова к установке. Откройте лаунчер, чтобы обновить игру.",
+      "installButton": "Обновить"
     }
   }
 }

--- a/Services/IQueueSocketService.cs
+++ b/Services/IQueueSocketService.cs
@@ -25,6 +25,7 @@ public interface IQueueSocketService : IDisposable
     event Action<PleaseEnterQueueMessage>? PleaseEnterQueue;
 
     Task ConnectAsync(string token, CancellationToken cancellationToken = default);
+    Task ReconnectAsync(CancellationToken cancellationToken = default);
     Task DisconnectAsync(CancellationToken cancellationToken = default);
 
     Task EnterQueueAsync(MatchmakingMode[] modes, CancellationToken cancellationToken = default);

--- a/Services/IRemoteManifestService.cs
+++ b/Services/IRemoteManifestService.cs
@@ -1,0 +1,28 @@
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using d2c_launcher.Models;
+
+namespace d2c_launcher.Services;
+
+public sealed class RemotePackageManifest
+{
+    public required ContentPackage Package { get; init; }
+    public required GameManifest Manifest { get; init; }
+}
+
+public sealed class RemoteManifestSet
+{
+    public IReadOnlyList<RemotePackageManifest> Packages { get; init; } = [];
+    public GameManifest CombinedManifest { get; init; } = new();
+    public IReadOnlyList<string> InstalledPackageIds { get; init; } = [];
+}
+
+public interface IRemoteManifestService
+{
+    Task<RemoteManifestSet> GetInstalledPackageManifestsAsync(
+        IReadOnlyCollection<string>? selectedDlcIds,
+        bool includeOptionalPackages = false,
+        bool forceRefreshRegistry = false,
+        CancellationToken cancellationToken = default);
+}

--- a/Services/IToastNotificationService.cs
+++ b/Services/IToastNotificationService.cs
@@ -4,6 +4,7 @@ public interface IToastNotificationService
 {
     void ShowMatchFound(string roomId);
     void ShowPartyInvite(string inviteId, string inviterName);
+    void ShowGameUpdateAvailable();
     void Show(string title, string body, string? tag = null, string? launchArg = null);
     void ShowGoQueue(string title, string body, int modeId);
 }

--- a/Services/QueueSocketService.cs
+++ b/Services/QueueSocketService.cs
@@ -97,6 +97,15 @@ public sealed class QueueSocketService : IQueueSocketService
         await socket.ConnectAsync().ConfigureAwait(false);
     }
 
+    public async Task ReconnectAsync(CancellationToken cancellationToken = default)
+    {
+        var token = _token;
+        if (string.IsNullOrWhiteSpace(token))
+            return;
+        await DisconnectAsync(cancellationToken).ConfigureAwait(false);
+        await ConnectAsync(token, cancellationToken).ConfigureAwait(false);
+    }
+
     public async Task DisconnectAsync(CancellationToken cancellationToken = default)
     {
         if (_socket == null)

--- a/Services/RemoteManifestService.cs
+++ b/Services/RemoteManifestService.cs
@@ -1,0 +1,96 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using d2c_launcher.Models;
+
+namespace d2c_launcher.Services;
+
+public sealed class RemoteManifestService : IRemoteManifestService, IDisposable
+{
+    private const string BaseManifestUrl = "https://launcher.dotaclassic.ru/files/";
+
+    private readonly IContentRegistryService _registryService;
+    private readonly HttpClient _httpClient = new();
+
+    public RemoteManifestService(IContentRegistryService registryService)
+    {
+        _registryService = registryService;
+    }
+
+    public async Task<RemoteManifestSet> GetInstalledPackageManifestsAsync(
+        IReadOnlyCollection<string>? selectedDlcIds,
+        bool includeOptionalPackages = false,
+        bool forceRefreshRegistry = false,
+        CancellationToken cancellationToken = default)
+    {
+        if (forceRefreshRegistry)
+            _registryService.Invalidate();
+
+        var registry = await _registryService.GetAsync();
+        if (registry == null || registry.Packages.Count == 0)
+            throw new Exception(Resources.Strings.FailedToLoadPackages);
+
+        var selectedIds = (selectedDlcIds ?? []).ToHashSet(StringComparer.OrdinalIgnoreCase);
+        var packagesToInstall = registry.Packages
+            .Where(p => !p.Optional || includeOptionalPackages || selectedIds.Contains(p.Id))
+            .ToList();
+
+        var packageManifests = new List<RemotePackageManifest>(packagesToInstall.Count);
+
+        foreach (var pkg in packagesToInstall)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            var manifestUrl = $"{BaseManifestUrl}{pkg.Folder}/manifest.json";
+            var json = await _httpClient.GetStringAsync(manifestUrl, cancellationToken);
+            var manifest = JsonSerializer.Deserialize<GameManifest>(json)
+                ?? throw new Exception($"Манифест пакета {pkg.Name} пустой.");
+
+            foreach (var file in manifest.Files)
+            {
+                file.PackageFolder = pkg.Folder;
+                file.PackageName = pkg.Name;
+            }
+
+            packageManifests.Add(new RemotePackageManifest
+            {
+                Package = pkg,
+                Manifest = manifest,
+            });
+        }
+
+        return new RemoteManifestSet
+        {
+            Packages = packageManifests,
+            CombinedManifest = Combine(packageManifests.SelectMany(p => p.Manifest.Files)),
+            InstalledPackageIds = packagesToInstall.Select(p => p.Id).ToList(),
+        };
+    }
+
+    private static GameManifest Combine(IEnumerable<GameManifestFile> files)
+    {
+        // Later packages win when two manifests address the same path.
+        var byPath = new Dictionary<string, GameManifestFile>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var file in files)
+        {
+            byPath[file.Path] = new GameManifestFile
+            {
+                Path = file.Path,
+                Hash = file.Hash,
+                Size = file.Size,
+                Mode = file.Mode,
+                PackageFolder = file.PackageFolder,
+                PackageName = file.PackageName,
+            };
+        }
+
+        return new GameManifest { Files = byPath.Values.ToList() };
+    }
+
+    public void Dispose() => _httpClient.Dispose();
+}

--- a/Services/RemoteManifestService.cs
+++ b/Services/RemoteManifestService.cs
@@ -1,8 +1,10 @@
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Net.Http;
 using System.Text.Json;
+using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
 using d2c_launcher.Models;
@@ -12,9 +14,10 @@ namespace d2c_launcher.Services;
 public sealed class RemoteManifestService : IRemoteManifestService, IDisposable
 {
     private const string BaseManifestUrl = "https://launcher.dotaclassic.ru/files/";
+    private static readonly Regex SafeFolderName = new(@"^[a-zA-Z0-9_\-]+$", RegexOptions.Compiled);
 
     private readonly IContentRegistryService _registryService;
-    private readonly HttpClient _httpClient = new();
+    private readonly HttpClient _httpClient = new() { Timeout = TimeSpan.FromSeconds(15) };
 
     public RemoteManifestService(IContentRegistryService registryService)
     {
@@ -39,29 +42,8 @@ public sealed class RemoteManifestService : IRemoteManifestService, IDisposable
             .Where(p => !p.Optional || includeOptionalPackages || selectedIds.Contains(p.Id))
             .ToList();
 
-        var packageManifests = new List<RemotePackageManifest>(packagesToInstall.Count);
-
-        foreach (var pkg in packagesToInstall)
-        {
-            cancellationToken.ThrowIfCancellationRequested();
-
-            var manifestUrl = $"{BaseManifestUrl}{pkg.Folder}/manifest.json";
-            var json = await _httpClient.GetStringAsync(manifestUrl, cancellationToken);
-            var manifest = JsonSerializer.Deserialize<GameManifest>(json)
-                ?? throw new Exception(I18n.T("game.emptyPackageManifest", ("name", pkg.Name)));
-
-            foreach (var file in manifest.Files)
-            {
-                file.PackageFolder = pkg.Folder;
-                file.PackageName = pkg.Name;
-            }
-
-            packageManifests.Add(new RemotePackageManifest
-            {
-                Package = pkg,
-                Manifest = manifest,
-            });
-        }
+        var tasks = packagesToInstall.Select(pkg => FetchPackageManifestAsync(pkg, cancellationToken));
+        var packageManifests = (await Task.WhenAll(tasks)).ToList();
 
         return new RemoteManifestSet
         {
@@ -71,24 +53,34 @@ public sealed class RemoteManifestService : IRemoteManifestService, IDisposable
         };
     }
 
+    private async Task<RemotePackageManifest> FetchPackageManifestAsync(ContentPackage pkg, CancellationToken cancellationToken)
+    {
+        if (!SafeFolderName.IsMatch(pkg.Folder))
+            throw new Exception($"Invalid package folder name: {pkg.Folder}");
+
+        var manifestUrl = $"{BaseManifestUrl}{pkg.Folder}/manifest.json";
+        var json = await _httpClient.GetStringAsync(manifestUrl, cancellationToken);
+        var manifest = JsonSerializer.Deserialize<GameManifest>(json)
+            ?? throw new Exception(I18n.T("game.emptyPackageManifest", ("name", pkg.Name)));
+
+        foreach (var file in manifest.Files)
+        {
+            if (Path.IsPathRooted(file.Path) || file.Path.Contains(".."))
+                throw new Exception($"Unsafe path in manifest for package {pkg.Name}: {file.Path}");
+
+            file.PackageFolder = pkg.Folder;
+            file.PackageName = pkg.Name;
+        }
+
+        return new RemotePackageManifest { Package = pkg, Manifest = manifest };
+    }
+
     private static GameManifest Combine(IEnumerable<GameManifestFile> files)
     {
         // Later packages win when two manifests address the same path.
         var byPath = new Dictionary<string, GameManifestFile>(StringComparer.OrdinalIgnoreCase);
-
         foreach (var file in files)
-        {
-            byPath[file.Path] = new GameManifestFile
-            {
-                Path = file.Path,
-                Hash = file.Hash,
-                Size = file.Size,
-                Mode = file.Mode,
-                PackageFolder = file.PackageFolder,
-                PackageName = file.PackageName,
-            };
-        }
-
+            byPath[file.Path] = file;
         return new GameManifest { Files = byPath.Values.ToList() };
     }
 

--- a/Services/RemoteManifestService.cs
+++ b/Services/RemoteManifestService.cs
@@ -48,7 +48,7 @@ public sealed class RemoteManifestService : IRemoteManifestService, IDisposable
             var manifestUrl = $"{BaseManifestUrl}{pkg.Folder}/manifest.json";
             var json = await _httpClient.GetStringAsync(manifestUrl, cancellationToken);
             var manifest = JsonSerializer.Deserialize<GameManifest>(json)
-                ?? throw new Exception($"Манифест пакета {pkg.Name} пустой.");
+                ?? throw new Exception(I18n.T("game.emptyPackageManifest", ("name", pkg.Name)));
 
             foreach (var file in manifest.Files)
             {

--- a/Services/ToastNotificationService.cs
+++ b/Services/ToastNotificationService.cs
@@ -61,6 +61,27 @@ public sealed class ToastNotificationService : IToastNotificationService
         }
     }
 
+    public void ShowGameUpdateAvailable()
+    {
+        try
+        {
+            var content = new ToastContentBuilder()
+                .AddText(I18n.T("toast.gameUpdate.title"))
+                .AddText(I18n.T("toast.gameUpdate.body"))
+                .AddButton(new ToastButton(I18n.T("toast.gameUpdate.installButton"), LaunchGameArg))
+                .GetToastContent();
+            content.Launch = LaunchGameArg;
+
+            ToastNotificationManagerCompat.History.Remove("game-update");
+            var toast = new ToastNotification(content.GetXml()) { Tag = "game-update" };
+            _notifier.Show(toast);
+        }
+        catch (Exception ex)
+        {
+            AppLog.Error("Failed to show game update toast notification.", ex);
+        }
+    }
+
     public void Show(string title, string body, string? tag = null, string? launchArg = null)
     {
         try

--- a/ViewModels/GameDownloadViewModel.cs
+++ b/ViewModels/GameDownloadViewModel.cs
@@ -2,8 +2,6 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
-using System.Net.Http;
-using System.Text.Json;
 using System.Threading.Tasks;
 using Avalonia.Threading;
 using CommunityToolkit.Mvvm.ComponentModel;
@@ -17,13 +15,11 @@ namespace d2c_launcher.ViewModels;
 
 public partial class GameDownloadViewModel : ViewModelBase
 {
-    private const string BaseManifestUrl = "https://launcher.dotaclassic.ru/files/";
-
-    private readonly IContentRegistryService _registryService;
     private readonly ILocalManifestService _localManifestService;
     private readonly IManifestDiffService _manifestDiffService;
     private readonly IGameDownloadService _gameDownloadService;
     private readonly RedistInstallService _redistInstallService;
+    private readonly IRemoteManifestService _remoteManifestService;
 
     public string GameDirectory { get; set; } = "";
     public VerificationMode VerificationMode { get; set; } = VerificationMode.Foreground;
@@ -35,6 +31,7 @@ public partial class GameDownloadViewModel : ViewModelBase
     public List<string>? SelectedDlcIds { get; set; }
 
     public Action? OnCompleted { get; set; }
+    public Action<GameManifest>? OnCompletedWithManifest { get; set; }
 
     /// <summary>
     /// Called when the selected game directory is not a valid Dota 2 Classic installation.
@@ -77,17 +74,17 @@ public partial class GameDownloadViewModel : ViewModelBase
     [ObservableProperty] private string _errorText = "";
 
     public GameDownloadViewModel(
-        IContentRegistryService registryService,
         ILocalManifestService localManifestService,
         IManifestDiffService manifestDiffService,
         IGameDownloadService gameDownloadService,
-        RedistInstallService redistInstallService)
+        RedistInstallService redistInstallService,
+        IRemoteManifestService remoteManifestService)
     {
-        _registryService = registryService;
         _localManifestService = localManifestService;
         _manifestDiffService = manifestDiffService;
         _gameDownloadService = gameDownloadService;
         _redistInstallService = redistInstallService;
+        _remoteManifestService = remoteManifestService;
     }
 
     public void StartAsync() => _ = RunAsync();
@@ -143,13 +140,14 @@ public partial class GameDownloadViewModel : ViewModelBase
         {
             await RunDefenderPhaseAsync();
             await DeleteRemovedPackagesAsync();
-            var packages = await FetchAllPackageManifestsAsync();
+            var remoteManifestSet = await FetchInstalledPackageManifestsAsync();
+            var packages = remoteManifestSet.Packages;
             var local = await ScanLocalFilesAsync();
 
             bool anyDownloaded = false;
-            foreach (var (_, pkgManifest) in packages)
+            foreach (var packageManifest in packages)
             {
-                var toDownload = ComputeDiff(pkgManifest, local,
+                var toDownload = ComputeDiff(packageManifest.Manifest, local,
                     out int totalRemoteFiles, out long totalRemoteBytes, out long alreadyOkBytes);
 
                 if (toDownload.Count == 0)
@@ -165,6 +163,7 @@ public partial class GameDownloadViewModel : ViewModelBase
             Dispatcher.UIThread.Post(() =>
             {
                 OnPackagesInstalled?.Invoke(_pendingInstalledPackageIds);
+                OnCompletedWithManifest?.Invoke(remoteManifestSet.CombinedManifest);
                 OnCompleted?.Invoke();
             });
         }
@@ -219,14 +218,19 @@ public partial class GameDownloadViewModel : ViewModelBase
 
     private async Task DeleteRemovedPackagesAsync()
     {
-        var registry = await _registryService.GetAsync();
-        if (registry == null) return;
+        var registry = await _remoteManifestService.GetInstalledPackageManifestsAsync(
+            SelectedDlcIds,
+            includeOptionalPackages: true);
+        var packageMap = registry.Packages
+            .Where(p => p.Package.Optional)
+            .ToDictionary(p => p.Package.Id, p => p, StringComparer.OrdinalIgnoreCase);
+        if (packageMap.Count == 0) return;
 
         // Delete files for every optional package the user has NOT selected.
         // File.Exists guards handle packages that were never on disk.
         var selectedIds = (SelectedDlcIds ?? []).ToHashSet(StringComparer.OrdinalIgnoreCase);
-        var packagesToRemove = registry.Packages
-            .Where(p => p.Optional && !selectedIds.Contains(p.Id))
+        var packagesToRemove = packageMap.Values
+            .Where(p => !selectedIds.Contains(p.Package.Id))
             .ToList();
 
         if (packagesToRemove.Count == 0)
@@ -234,24 +238,13 @@ public partial class GameDownloadViewModel : ViewModelBase
 
         SetPhase(VerificationPhase.FetchingManifest, Strings.DeletingDlcFiles, indeterminate: true);
 
-        using var http = new HttpClient();
-
         foreach (var pkg in packagesToRemove)
         {
-
-            Dispatcher.UIThread.Post(() => CurrentFileText = pkg.Name);
-
-            var manifestUrl = $"{BaseManifestUrl}{pkg.Folder}/manifest.json";
-            string json;
-            try { json = await http.GetStringAsync(manifestUrl); }
-            catch { continue; }
-
-            var pkgManifest = JsonSerializer.Deserialize<GameManifest>(json);
-            if (pkgManifest == null) continue;
+            Dispatcher.UIThread.Post(() => CurrentFileText = pkg.Package.Name);
 
             await Task.Run(() =>
             {
-                foreach (var file in pkgManifest.Files)
+                foreach (var file in pkg.Manifest.Files)
                 {
                     var localPath = System.IO.Path.Combine(GameDirectory, file.Path);
                     try
@@ -267,50 +260,22 @@ public partial class GameDownloadViewModel : ViewModelBase
         Dispatcher.UIThread.Post(() => CurrentFileText = "");
     }
 
-    private async Task<List<(ContentPackage Package, GameManifest Manifest)>> FetchAllPackageManifestsAsync()
+    private async Task<RemoteManifestSet> FetchInstalledPackageManifestsAsync()
     {
         SetPhase(VerificationPhase.FetchingManifest, Strings.ConnectingToServer, indeterminate: true);
-
-        var registry = await _registryService.GetAsync();
-
-        if (registry == null || registry.Packages.Count == 0)
-            throw new Exception(Strings.FailedToLoadPackages);
-
-        // Determine which packages to download: all required + user-selected optional
-        var packagesToInstall = registry.Packages
-            .Where(p => !p.Optional || (SelectedDlcIds != null && SelectedDlcIds.Contains(p.Id)))
-            .ToList();
-
-        _pendingInstalledPackageIds = packagesToInstall.Select(p => p.Id).ToList();
+        var remoteManifestSet = await _remoteManifestService.GetInstalledPackageManifestsAsync(SelectedDlcIds);
+        _pendingInstalledPackageIds = remoteManifestSet.InstalledPackageIds.ToList();
 
         SetPhase(VerificationPhase.FetchingPackageManifests,
-            $"Загрузка манифестов ({packagesToInstall.Count} пакетов)...", indeterminate: true);
+            $"Загрузка манифестов ({remoteManifestSet.Packages.Count} пакетов)...", indeterminate: true);
 
-        var result = new List<(ContentPackage, GameManifest)>();
-        using var http = new HttpClient();
-
-        foreach (var pkg in packagesToInstall)
+        foreach (var pkg in remoteManifestSet.Packages)
         {
-            Dispatcher.UIThread.Post(() => CurrentFileText = pkg.Name);
-
-            var manifestUrl = $"{BaseManifestUrl}{pkg.Folder}/manifest.json";
-            var json = await http.GetStringAsync(manifestUrl);
-            var pkgManifest = JsonSerializer.Deserialize<GameManifest>(json)
-                ?? throw new Exception($"Манифест пакета {pkg.Name} пустой.");
-
-            // Annotate each file with its package folder for download URL construction
-            foreach (var file in pkgManifest.Files)
-            {
-                file.PackageFolder = pkg.Folder;
-                file.PackageName = pkg.Name;
-            }
-
-            result.Add((pkg, pkgManifest));
+            Dispatcher.UIThread.Post(() => CurrentFileText = pkg.Package.Name);
         }
 
         Dispatcher.UIThread.Post(() => CurrentFileText = "");
-
-        return result;
+        return remoteManifestSet;
     }
 
     private async Task<GameManifest> ScanLocalFilesAsync()

--- a/ViewModels/GameLaunchViewModel.cs
+++ b/ViewModels/GameLaunchViewModel.cs
@@ -77,16 +77,14 @@ public partial class GameLaunchViewModel : ViewModelBase, IDisposable
 
     public bool IsLaunchEnabled => !IsGameDirectorySet || RunState == GameRunState.None;
 
-    public string PlayButtonText => IsGameUpdatePending && RunState == GameRunState.None
-        ? I18n.T("game.update")
-        : RunState is GameRunState.OurGameRunning or GameRunState.OtherDotaRunning
+    public string PlayButtonText => RunState is GameRunState.OurGameRunning or GameRunState.OtherDotaRunning
         ? Strings.StopLabel
         : Strings.Launch;
 
     public bool PlayButtonIsStop => RunState is GameRunState.OurGameRunning or GameRunState.OtherDotaRunning;
 
-    public bool IsPlayButtonEnabled => !IsGameUpdatePending || RunState != GameRunState.None;
-    public bool ShowPlayButtonIcon => !PlayButtonIsStop && !IsGameUpdatePending;
+    public bool IsPlayButtonEnabled => PlayButtonIsStop || IsGameDirectorySet;
+    public bool ShowPlayButtonIcon => !PlayButtonIsStop;
 
     public GameLaunchViewModel(
         ISettingsStorage settingsStorage,
@@ -228,8 +226,6 @@ public partial class GameLaunchViewModel : ViewModelBase, IDisposable
     {
         if (string.IsNullOrEmpty(GameDirectory))
             return false;
-        if (IsGameUpdatePending)
-            return false;
         try
         {
             var exePath = Path.Combine(GameDirectory, "dota.exe");
@@ -299,9 +295,6 @@ public partial class GameLaunchViewModel : ViewModelBase, IDisposable
 
     public void ConnectToGame()
     {
-        if (IsGameUpdatePending && RunState == GameRunState.None)
-            return;
-
         _connectCts?.Cancel();
         _connectCts = new CancellationTokenSource();
         _ = ConnectToGameAsync(_connectCts.Token, playSound: true);

--- a/ViewModels/GameLaunchViewModel.cs
+++ b/ViewModels/GameLaunchViewModel.cs
@@ -46,11 +46,15 @@ public partial class GameLaunchViewModel : ViewModelBase, IDisposable
     [ObservableProperty]
     private bool? _canAbandonFromServer;
 
+    [ObservableProperty]
+    private bool _isGameUpdatePending;
+
     public bool HasServerUrl => !string.IsNullOrEmpty(ServerUrl);
 
     partial void OnServerUrlChanged(string? value) => OnPropertyChanged(nameof(HasServerUrl));
 
     partial void OnRunStateChanged(GameRunState value) => NotifyLaunchProps();
+    partial void OnIsGameUpdatePendingChanged(bool value) => NotifyLaunchProps();
 
     partial void OnGameDirectoryChanged(string? value)
     {
@@ -73,11 +77,16 @@ public partial class GameLaunchViewModel : ViewModelBase, IDisposable
 
     public bool IsLaunchEnabled => !IsGameDirectorySet || RunState == GameRunState.None;
 
-    public string PlayButtonText => RunState is GameRunState.OurGameRunning or GameRunState.OtherDotaRunning
+    public string PlayButtonText => IsGameUpdatePending && RunState == GameRunState.None
+        ? I18n.T("game.update")
+        : RunState is GameRunState.OurGameRunning or GameRunState.OtherDotaRunning
         ? Strings.StopLabel
         : Strings.Launch;
 
     public bool PlayButtonIsStop => RunState is GameRunState.OurGameRunning or GameRunState.OtherDotaRunning;
+
+    public bool IsPlayButtonEnabled => !IsGameUpdatePending || RunState != GameRunState.None;
+    public bool ShowPlayButtonIcon => !PlayButtonIsStop && !IsGameUpdatePending;
 
     public GameLaunchViewModel(
         ISettingsStorage settingsStorage,
@@ -219,6 +228,8 @@ public partial class GameLaunchViewModel : ViewModelBase, IDisposable
     {
         if (string.IsNullOrEmpty(GameDirectory))
             return false;
+        if (IsGameUpdatePending)
+            return false;
         try
         {
             var exePath = Path.Combine(GameDirectory, "dota.exe");
@@ -288,6 +299,9 @@ public partial class GameLaunchViewModel : ViewModelBase, IDisposable
 
     public void ConnectToGame()
     {
+        if (IsGameUpdatePending && RunState == GameRunState.None)
+            return;
+
         _connectCts?.Cancel();
         _connectCts = new CancellationTokenSource();
         _ = ConnectToGameAsync(_connectCts.Token, playSound: true);
@@ -589,6 +603,8 @@ public partial class GameLaunchViewModel : ViewModelBase, IDisposable
         OnPropertyChanged(nameof(IsLaunchEnabled));
         OnPropertyChanged(nameof(PlayButtonText));
         OnPropertyChanged(nameof(PlayButtonIsStop));
+        OnPropertyChanged(nameof(IsPlayButtonEnabled));
+        OnPropertyChanged(nameof(ShowPlayButtonIcon));
     }
 
     public void Dispose()

--- a/ViewModels/MainLauncherViewModel.cs
+++ b/ViewModels/MainLauncherViewModel.cs
@@ -37,6 +37,7 @@ public partial class MainLauncherViewModel : ViewModelBase, IDisposable
 
     /// <summary>Called when the user requests game re-verification (e.g. after corrupted files detected).</summary>
     public Action? RequestReverify { get; set; }
+    public Action? RequestInstallGameUpdate { get; set; }
     private readonly DispatcherTimer _onlineStatsTimer;
     private readonly SocketEventCoordinator _soundCoordinator;
     private readonly Action<OnlineUpdateMessage> _onlineUpdatedHandler;
@@ -80,8 +81,17 @@ public partial class MainLauncherViewModel : ViewModelBase, IDisposable
     [ObservableProperty]
     private bool _isAbandonConfirmOpen;
 
+    [ObservableProperty]
+    private bool _isGameUpdatePending;
+
+    [ObservableProperty]
+    private bool _isGameUpdatePromptOpen;
+
     /// <summary>True when the server reports an active game that can be abandoned.</summary>
     public bool CanAbandonGame => Launch.HasServerUrl && (Launch.CanAbandonFromServer ?? false);
+    public string GameUpdatePromptText => Launch.RunState != GameRunState.None
+        ? I18n.T("game.updatePromptRunning")
+        : I18n.T("game.updatePromptIdle");
 
     [ObservableProperty]
     private int _onlineInGame;
@@ -159,6 +169,7 @@ public partial class MainLauncherViewModel : ViewModelBase, IDisposable
             NotificationArea.AddToast(Strings.SelectAtLeastOneMode);
         Queue.ShowRestrictedModesRemovedToast = () =>
             NotificationArea.AddToast(Strings.RestrictedModesUnselected);
+        Queue.InstallPendingGameUpdate = InstallPendingGameUpdate;
         Launch.OnExeNotFound = () =>
             NotificationArea.AddCorruptedFilesToast(() => RequestReverify?.Invoke());
         Party.ShowInviteSentToast = (name, initials, avatarUrl) =>
@@ -185,6 +196,8 @@ public partial class MainLauncherViewModel : ViewModelBase, IDisposable
         {
             if (e.PropertyName is nameof(GameLaunchViewModel.HasServerUrl) or nameof(GameLaunchViewModel.CanAbandonFromServer))
                 OnPropertyChanged(nameof(CanAbandonGame));
+            if (e.PropertyName is nameof(GameLaunchViewModel.PlayButtonIsStop) or nameof(GameLaunchViewModel.RunState))
+                OnPropertyChanged(nameof(GameUpdatePromptText));
         };
 
         // Wire delegates into children that need auth state
@@ -296,6 +309,30 @@ public partial class MainLauncherViewModel : ViewModelBase, IDisposable
         }
     }
 
+    [RelayCommand]
+    private void DismissGameUpdatePrompt() => IsGameUpdatePromptOpen = false;
+
+    [RelayCommand]
+    private void InstallGameUpdate()
+    {
+        IsGameUpdatePromptOpen = false;
+        InstallPendingGameUpdateAsync().FireAndForget("InstallPendingGameUpdateAsync (modal)");
+    }
+
+    private void InstallPendingGameUpdate()
+    {
+        InstallPendingGameUpdateAsync().FireAndForget("InstallPendingGameUpdateAsync");
+    }
+
+    private async Task InstallPendingGameUpdateAsync()
+    {
+        if (Launch.PlayButtonIsStop)
+            Launch.StopGame();
+
+        await _queueSocketService.LeaveAllQueuesAsync();
+        RequestInstallGameUpdate?.Invoke();
+    }
+
     partial void OnActiveTabChanged(LauncherTab value)
     {
         OnPropertyChanged(nameof(IsPlayTabActive));
@@ -388,6 +425,24 @@ public partial class MainLauncherViewModel : ViewModelBase, IDisposable
     public void OpenInviteModal() => Party.OpenInviteModal();
     public void CloseInviteModal() => Party.CloseInviteModal();
     public async Task InvitePlayerAsync(d2c_launcher.Models.InviteCandidateView candidate) => await Party.InvitePlayerAsync(candidate);
+
+    public void SetGameUpdatePending(bool pending)
+    {
+        var changed = IsGameUpdatePending != pending;
+        IsGameUpdatePending = pending;
+        Launch.IsGameUpdatePending = pending;
+        Queue.IsGameUpdatePending = pending;
+
+        if (pending)
+        {
+            if (changed)
+                IsGameUpdatePromptOpen = true;
+        }
+        else
+        {
+            IsGameUpdatePromptOpen = false;
+        }
+    }
 
     /// <summary>
     /// Dev shortcut (F12, nightly only): shows a fake winStreak10 achievement toast.

--- a/ViewModels/MainLauncherViewModel.cs
+++ b/ViewModels/MainLauncherViewModel.cs
@@ -279,13 +279,16 @@ public partial class MainLauncherViewModel : ViewModelBase, IDisposable
 
     public async Task ToggleSearchAsync()
     {
-        if (Launch.HasServerUrl)
+        if (ShouldConnectToGame(Launch.HasServerUrl))
         {
             Launch.ConnectToGame();
             return;
         }
+
         await Queue.ToggleSearchAsync();
     }
+
+    internal static bool ShouldConnectToGame(bool hasServerUrl) => hasServerUrl;
 
     [RelayCommand]
     private void RequestAbandonGame() => IsAbandonConfirmOpen = true;
@@ -329,7 +332,11 @@ public partial class MainLauncherViewModel : ViewModelBase, IDisposable
         if (Launch.PlayButtonIsStop)
             Launch.StopGame();
 
-        await _queueSocketService.LeaveAllQueuesAsync();
+        // Preserve reconnectable game state: only leave matchmaking if we're still searching
+        // and do not already have a server to connect to.
+        if (Queue.IsSearching && !Launch.HasServerUrl)
+            await _queueSocketService.LeaveAllQueuesAsync();
+
         RequestInstallGameUpdate?.Invoke();
     }
 
@@ -458,6 +465,20 @@ public partial class MainLauncherViewModel : ViewModelBase, IDisposable
             api: _backendApiService,
             cp: 10);
         if (vm != null) NotificationArea.AddNotificationDirect(vm);
+    }
+
+    /// <summary>
+    /// Dev shortcut (nightly only): toggles the pending-game-update UI state locally.
+    /// </summary>
+    public void ToggleDevGameUpdatePending()
+    {
+        if (!_settingsStorage.Get().NightlyUpdates) return;
+
+        var next = !IsGameUpdatePending;
+        SetGameUpdatePending(next);
+        NotificationArea.AddToast(next
+            ? I18n.T("toast.dev.gameUpdateEnabled")
+            : I18n.T("toast.dev.gameUpdateDisabled"));
     }
 
     private static string? BuildStreamsSettingsUrl(Models.User? user) =>

--- a/ViewModels/MainLauncherViewModel.cs
+++ b/ViewModels/MainLauncherViewModel.cs
@@ -279,7 +279,7 @@ public partial class MainLauncherViewModel : ViewModelBase, IDisposable
 
     public async Task ToggleSearchAsync()
     {
-        if (ShouldConnectToGame(Launch.HasServerUrl))
+        if (Launch.HasServerUrl)
         {
             Launch.ConnectToGame();
             return;
@@ -287,8 +287,6 @@ public partial class MainLauncherViewModel : ViewModelBase, IDisposable
 
         await Queue.ToggleSearchAsync();
     }
-
-    internal static bool ShouldConnectToGame(bool hasServerUrl) => hasServerUrl;
 
     [RelayCommand]
     private void RequestAbandonGame() => IsAbandonConfirmOpen = true;

--- a/ViewModels/MainWindowViewModel.cs
+++ b/ViewModels/MainWindowViewModel.cs
@@ -16,9 +16,10 @@ using Microsoft.Win32;
 
 namespace d2c_launcher.ViewModels;
 
-public partial class MainWindowViewModel : ViewModelBase
+public partial class MainWindowViewModel : ViewModelBase, IDisposable
 {
     private static readonly TimeSpan BackgroundVerificationDelay = TimeSpan.FromSeconds(45);
+    private static readonly TimeSpan RemoteUpdatePollInterval = TimeSpan.FromMinutes(3);
 
     private readonly ISteamManager _steamManager;
     private readonly ISettingsStorage _settingsStorage;
@@ -33,6 +34,7 @@ public partial class MainWindowViewModel : ViewModelBase
     private readonly ILocalManifestService _localManifestService;
     private readonly IManifestDiffService _manifestDiffService;
     private readonly IGameDownloadService _gameDownloadService;
+    private readonly IRemoteManifestService _remoteManifestService;
     private readonly RedistInstallService _redistInstallService;
     private readonly IContentRegistryService _registryService;
     private readonly IWindowService _windowService;
@@ -45,6 +47,7 @@ public partial class MainWindowViewModel : ViewModelBase
     private readonly IToastNotificationService _toastNotificationService;
     private readonly IStartupRegistrationService _startupRegistrationService;
     private readonly AppStartupContext _startupContext;
+    private readonly IUiTimer _remoteUpdatePollTimer;
 
     /// <summary>Pending spectate match ID received before the Launcher state was entered.</summary>
     private int? _pendingSpectateMatchId;
@@ -58,6 +61,9 @@ public partial class MainWindowViewModel : ViewModelBase
     private bool _backgroundWindowMode;
     private bool _verificationSatisfied;
     private bool _backgroundVerificationStarted;
+    private bool _remoteUpdateCheckInFlight;
+    private bool _gameUpdateToastShownForCurrentPendingState;
+    private GameManifest? _verifiedLocalManifestSnapshot;
 
     [ObservableProperty]
     private AppState _appState;
@@ -100,6 +106,7 @@ public partial class MainWindowViewModel : ViewModelBase
         ILocalManifestService localManifestService,
         IManifestDiffService manifestDiffService,
         IGameDownloadService gameDownloadService,
+        IRemoteManifestService remoteManifestService,
         RedistInstallService redistInstallService,
         IContentRegistryService registryService,
         IWindowService windowService,
@@ -126,6 +133,7 @@ public partial class MainWindowViewModel : ViewModelBase
         _localManifestService = localManifestService;
         _manifestDiffService = manifestDiffService;
         _gameDownloadService = gameDownloadService;
+        _remoteManifestService = remoteManifestService;
         _redistInstallService = redistInstallService;
         _registryService = registryService;
         _windowService = windowService;
@@ -139,6 +147,9 @@ public partial class MainWindowViewModel : ViewModelBase
         _startupRegistrationService = startupRegistrationService;
         _startupContext = startupContext;
         _backgroundWindowMode = startupContext.IsBackgroundStart;
+        _remoteUpdatePollTimer = timerFactory.Create();
+        _remoteUpdatePollTimer.Interval = RemoteUpdatePollInterval;
+        _remoteUpdatePollTimer.Tick += OnRemoteUpdatePollTick;
 
         _windowService.WindowShown += OnWindowShown;
 
@@ -262,6 +273,7 @@ public partial class MainWindowViewModel : ViewModelBase
                 _steamManager.OnSteamPolled += steamFirstVm.FireCheck;
                 _currentVmCleanup = () => _steamManager.OnSteamPolled -= steamFirstVm.FireCheck;
                 CurrentContentViewModel = steamFirstVm;
+                StopRemoteUpdatePolling();
                 break;
 
             case AppState.SelectGameDirectory:
@@ -290,6 +302,7 @@ public partial class MainWindowViewModel : ViewModelBase
                 };
                 _pendingSelectGameError = null;
                 CurrentContentViewModel = selectVm;
+                StopRemoteUpdatePolling();
                 break;
 
             case AppState.VerifyingGame:
@@ -297,6 +310,7 @@ public partial class MainWindowViewModel : ViewModelBase
                 if (CurrentContentViewModel is GameDownloadViewModel)
                     return;
                 EnterVerifyingGame(VerificationMode.Foreground);
+                StopRemoteUpdatePolling();
                 break;
 
             case AppState.Launcher:
@@ -323,7 +337,7 @@ public partial class MainWindowViewModel : ViewModelBase
         var settings = _settingsStorage.Get();
         bool needDefenderModal = settings.ShouldShowDefenderPrompt;
 
-        var vm = new GameDownloadViewModel(_registryService, _localManifestService, _manifestDiffService, _gameDownloadService, _redistInstallService)
+        var vm = new GameDownloadViewModel(_localManifestService, _manifestDiffService, _gameDownloadService, _redistInstallService, _remoteManifestService)
         {
             GameDirectory = gameDir,
             VerificationMode = verificationMode,
@@ -343,6 +357,7 @@ public partial class MainWindowViewModel : ViewModelBase
                 s.InstalledPackageIds = ids;
                 _settingsStorage.Save(s);
             },
+            OnCompletedWithManifest = manifest => _verifiedLocalManifestSnapshot = manifest,
             OnCompleted = () => Dispatcher.UIThread.Post(() =>
             {
                 _verificationSatisfied = true;
@@ -350,6 +365,7 @@ public partial class MainWindowViewModel : ViewModelBase
             }),
             OnInvalidGameDirectory = errorMessage => Dispatcher.UIThread.Post(() =>
             {
+                _verifiedLocalManifestSnapshot = null;
                 var s = _settingsStorage.Get();
                 s.GameDirectory = null;
                 _settingsStorage.Save(s);
@@ -393,9 +409,16 @@ public partial class MainWindowViewModel : ViewModelBase
             AppState = AppState.VerifyingGame;
             EnterVerifyingGame(VerificationMode.Foreground);
         });
+        vm.RequestInstallGameUpdate = () => Dispatcher.UIThread.Post(() =>
+        {
+            AppState = AppState.VerifyingGame;
+            EnterVerifyingGame(VerificationMode.Foreground);
+        });
+        vm.SetGameUpdatePending(false);
         CurrentContentViewModel = vm;
         if (_startupContext.IsBackgroundStart && !_verificationSatisfied)
             StartBackgroundVerificationIfNeeded();
+        StartRemoteUpdatePollingIfReady();
 
         if (_pendingSpectateMatchId.HasValue)
         {
@@ -628,6 +651,87 @@ public partial class MainWindowViewModel : ViewModelBase
 
         _backgroundVerificationStarted = true;
         _ = RunBackgroundVerificationAsync();
+    }
+
+    private void OnRemoteUpdatePollTick(object? sender, EventArgs e)
+    {
+        if (_remoteUpdateCheckInFlight)
+            return;
+
+        _ = CheckForRemoteGameUpdateAsync();
+    }
+
+    private void StartRemoteUpdatePollingIfReady()
+    {
+        if (_verifiedLocalManifestSnapshot == null || CurrentContentViewModel is not MainLauncherViewModel)
+            return;
+
+        _remoteUpdatePollTimer.Start();
+        _ = CheckForRemoteGameUpdateAsync();
+    }
+
+    private void StopRemoteUpdatePolling() => _remoteUpdatePollTimer.Stop();
+
+    private async Task CheckForRemoteGameUpdateAsync()
+    {
+        if (_remoteUpdateCheckInFlight ||
+            _verifiedLocalManifestSnapshot == null ||
+            CurrentContentViewModel is not MainLauncherViewModel launcherVm ||
+            CurrentContentViewModel is GameDownloadViewModel ||
+            !HasValidGameDir())
+        {
+            return;
+        }
+
+        _remoteUpdateCheckInFlight = true;
+        try
+        {
+            var selectedDlcIds = _settingsStorage.Get().SelectedDlcIds ?? [];
+            var remoteManifestSet = await _remoteManifestService.GetInstalledPackageManifestsAsync(
+                selectedDlcIds,
+                forceRefreshRegistry: true);
+            var hasUpdate = _manifestDiffService.ComputeFilesToDownload(
+                remoteManifestSet.CombinedManifest,
+                _verifiedLocalManifestSnapshot).Count > 0;
+
+            Dispatcher.UIThread.Post(() => ApplyRemoteGameUpdateState(launcherVm, hasUpdate));
+        }
+        catch (Exception ex)
+        {
+            AppLog.Error("[RemoteUpdatePoll] Failed to check for remote game updates", ex);
+        }
+        finally
+        {
+            _remoteUpdateCheckInFlight = false;
+        }
+    }
+
+    private void ApplyRemoteGameUpdateState(MainLauncherViewModel launcherVm, bool hasUpdate)
+    {
+        var wasPending = launcherVm.IsGameUpdatePending;
+        launcherVm.SetGameUpdatePending(hasUpdate);
+
+        if (!hasUpdate)
+        {
+            _gameUpdateToastShownForCurrentPendingState = false;
+            return;
+        }
+
+        if (wasPending || _gameUpdateToastShownForCurrentPendingState)
+            return;
+
+        if (_windowService.IsWindowVisible && _windowService.IsWindowActive)
+            return;
+
+        _toastNotificationService.ShowGameUpdateAvailable();
+        _gameUpdateToastShownForCurrentPendingState = true;
+    }
+
+    public void Dispose()
+    {
+        _remoteUpdatePollTimer.Tick -= OnRemoteUpdatePollTick;
+        _remoteUpdatePollTimer.Stop();
+        _windowService.WindowShown -= OnWindowShown;
     }
 
     private async Task RunBackgroundVerificationAsync()

--- a/ViewModels/MainWindowViewModel.cs
+++ b/ViewModels/MainWindowViewModel.cs
@@ -61,8 +61,7 @@ public partial class MainWindowViewModel : ViewModelBase, IDisposable
     private bool _backgroundWindowMode;
     private bool _verificationSatisfied;
     private bool _backgroundVerificationStarted;
-    private volatile bool _remoteUpdateCheckInFlight;
-    private bool _gameUpdateToastShownForCurrentPendingState;
+    private int _remoteUpdateCheckInFlight; // 0 = idle, 1 = in-flight; use Interlocked
     private GameManifest? _verifiedLocalManifestSnapshot;
 
     [ObservableProperty]
@@ -399,27 +398,19 @@ public partial class MainWindowViewModel : ViewModelBase, IDisposable
             _dotakeysProfileService, _toastNotificationService, _startupRegistrationService);
         vm.OnGameDirectoryChanged = _ => Dispatcher.UIThread.Post(() => EnterState(AppStateMachine.OnGameDirChanged(AppState)));
         vm.RequestGameDirectoryChange = () => Dispatcher.UIThread.Post(() => EnterState(AppState.SelectGameDirectory));
-        vm.OnDlcChanged = () => Dispatcher.UIThread.Post(() =>
+        void StartForegroundVerification() => Dispatcher.UIThread.Post(() =>
         {
             AppState = AppState.VerifyingGame;
             EnterVerifyingGame(VerificationMode.Foreground);
         });
-        vm.RequestReverify = () => Dispatcher.UIThread.Post(() =>
-        {
-            AppState = AppState.VerifyingGame;
-            EnterVerifyingGame(VerificationMode.Foreground);
-        });
-        vm.RequestInstallGameUpdate = () => Dispatcher.UIThread.Post(() =>
-        {
-            AppState = AppState.VerifyingGame;
-            EnterVerifyingGame(VerificationMode.Foreground);
-        });
+        vm.OnDlcChanged = StartForegroundVerification;
+        vm.RequestReverify = StartForegroundVerification;
+        vm.RequestInstallGameUpdate = StartForegroundVerification;
         vm.SetGameUpdatePending(false);
         CurrentContentViewModel = vm;
         if (_startupContext.IsBackgroundStart && !_verificationSatisfied)
             StartBackgroundVerificationIfNeeded();
         StartRemoteUpdatePollingIfReady();
-        _queueSocketService.ReconnectAsync().FireAndForget("ReconnectAsync on launcher mount");
 
         if (_pendingSpectateMatchId.HasValue)
         {
@@ -654,13 +645,8 @@ public partial class MainWindowViewModel : ViewModelBase, IDisposable
         _ = RunBackgroundVerificationAsync();
     }
 
-    private void OnRemoteUpdatePollTick(object? sender, EventArgs e)
-    {
-        if (_remoteUpdateCheckInFlight)
-            return;
-
-        _ = CheckForRemoteGameUpdateAsync();
-    }
+    private void OnRemoteUpdatePollTick(object? sender, EventArgs e) =>
+        CheckForRemoteGameUpdateAsync().FireAndForget("[RemoteUpdatePoll] tick");
 
     private void StartRemoteUpdatePollingIfReady()
     {
@@ -675,24 +661,24 @@ public partial class MainWindowViewModel : ViewModelBase, IDisposable
 
     private async Task CheckForRemoteGameUpdateAsync()
     {
-        if (_remoteUpdateCheckInFlight ||
-            _verifiedLocalManifestSnapshot == null ||
+        var localSnapshot = _verifiedLocalManifestSnapshot;
+        if (localSnapshot == null ||
             CurrentContentViewModel is not MainLauncherViewModel launcherVm ||
             !HasValidGameDir())
         {
             return;
         }
 
-        _remoteUpdateCheckInFlight = true;
+        if (System.Threading.Interlocked.CompareExchange(ref _remoteUpdateCheckInFlight, 1, 0) != 0)
+            return;
+
         try
         {
             var selectedDlcIds = _settingsStorage.Get().SelectedDlcIds ?? [];
-            var remoteManifestSet = await _remoteManifestService.GetInstalledPackageManifestsAsync(
-                selectedDlcIds,
-                forceRefreshRegistry: true);
+            var remoteManifestSet = await _remoteManifestService.GetInstalledPackageManifestsAsync(selectedDlcIds);
             var hasUpdate = _manifestDiffService.ComputeFilesToDownload(
                 remoteManifestSet.CombinedManifest,
-                _verifiedLocalManifestSnapshot).Count > 0;
+                localSnapshot).Count > 0;
 
             Dispatcher.UIThread.Post(() => ApplyRemoteGameUpdateState(launcherVm, hasUpdate));
         }
@@ -702,7 +688,7 @@ public partial class MainWindowViewModel : ViewModelBase, IDisposable
         }
         finally
         {
-            _remoteUpdateCheckInFlight = false;
+            System.Threading.Interlocked.Exchange(ref _remoteUpdateCheckInFlight, 0);
         }
     }
 
@@ -714,15 +700,7 @@ public partial class MainWindowViewModel : ViewModelBase, IDisposable
         var wasPending = launcherVm.IsGameUpdatePending;
         launcherVm.SetGameUpdatePending(hasUpdate);
 
-        if (!hasUpdate)
-        {
-            _gameUpdateToastShownForCurrentPendingState = false;
-            return;
-        }
-
-        _gameUpdateToastShownForCurrentPendingState = true;
-
-        if (wasPending)
+        if (!hasUpdate || wasPending)
             return;
 
         if (_windowService.IsWindowVisible && _windowService.IsWindowActive)

--- a/ViewModels/MainWindowViewModel.cs
+++ b/ViewModels/MainWindowViewModel.cs
@@ -61,7 +61,7 @@ public partial class MainWindowViewModel : ViewModelBase, IDisposable
     private bool _backgroundWindowMode;
     private bool _verificationSatisfied;
     private bool _backgroundVerificationStarted;
-    private bool _remoteUpdateCheckInFlight;
+    private volatile bool _remoteUpdateCheckInFlight;
     private bool _gameUpdateToastShownForCurrentPendingState;
     private GameManifest? _verifiedLocalManifestSnapshot;
 
@@ -419,6 +419,7 @@ public partial class MainWindowViewModel : ViewModelBase, IDisposable
         if (_startupContext.IsBackgroundStart && !_verificationSatisfied)
             StartBackgroundVerificationIfNeeded();
         StartRemoteUpdatePollingIfReady();
+        _queueSocketService.ReconnectAsync().FireAndForget("ReconnectAsync on launcher mount");
 
         if (_pendingSpectateMatchId.HasValue)
         {
@@ -677,7 +678,6 @@ public partial class MainWindowViewModel : ViewModelBase, IDisposable
         if (_remoteUpdateCheckInFlight ||
             _verifiedLocalManifestSnapshot == null ||
             CurrentContentViewModel is not MainLauncherViewModel launcherVm ||
-            CurrentContentViewModel is GameDownloadViewModel ||
             !HasValidGameDir())
         {
             return;
@@ -708,6 +708,9 @@ public partial class MainWindowViewModel : ViewModelBase, IDisposable
 
     private void ApplyRemoteGameUpdateState(MainLauncherViewModel launcherVm, bool hasUpdate)
     {
+        if (CurrentContentViewModel != launcherVm)
+            return;
+
         var wasPending = launcherVm.IsGameUpdatePending;
         launcherVm.SetGameUpdatePending(hasUpdate);
 
@@ -717,14 +720,15 @@ public partial class MainWindowViewModel : ViewModelBase, IDisposable
             return;
         }
 
-        if (wasPending || _gameUpdateToastShownForCurrentPendingState)
+        _gameUpdateToastShownForCurrentPendingState = true;
+
+        if (wasPending)
             return;
 
         if (_windowService.IsWindowVisible && _windowService.IsWindowActive)
             return;
 
         _toastNotificationService.ShowGameUpdateAvailable();
-        _gameUpdateToastShownForCurrentPendingState = true;
     }
 
     public void Dispose()

--- a/ViewModels/QueueViewModel.cs
+++ b/ViewModels/QueueViewModel.cs
@@ -45,6 +45,9 @@ public partial class QueueViewModel : ViewModelBase, IDisposable
     private bool _isSearching;
 
     [ObservableProperty]
+    private bool _isGameUpdatePending;
+
+    [ObservableProperty]
     private string _searchingModesText = Strings.NotInQueue;
 
     [ObservableProperty]
@@ -66,15 +69,18 @@ public partial class QueueViewModel : ViewModelBase, IDisposable
     private string _searchingInQueueText = "";
 
     /// <summary>Blue when game ready, green when searching, dark gray when idle.</summary>
-    public IBrush QueueButtonBackground => _hasServerUrl ? BrushReady
+    public IBrush QueueButtonBackground => IsGameUpdatePending ? BrushReady
+        : _hasServerUrl ? BrushReady
         : IsSearching ? BrushSearching : BrushIdle;
 
     /// <summary>Lighter version for hover state.</summary>
-    public IBrush QueueButtonHoverBackground => _hasServerUrl ? BrushReadyHover
+    public IBrush QueueButtonHoverBackground => IsGameUpdatePending ? BrushReadyHover
+        : _hasServerUrl ? BrushReadyHover
         : IsSearching ? BrushSearchingHover : BrushIdleHover;
 
     /// <summary>Subtle lighter border to give the button a framed look.</summary>
-    public IBrush QueueButtonBorderBrush => _hasServerUrl ? BrushBorderReady
+    public IBrush QueueButtonBorderBrush => IsGameUpdatePending ? BrushBorderReady
+        : _hasServerUrl ? BrushBorderReady
         : IsSearching ? BrushBorderSearching : BrushBorderIdle;
 
     /// <summary>Called when the user presses queue with no modes selected. Set by the parent VM.</summary>
@@ -82,6 +88,9 @@ public partial class QueueViewModel : ViewModelBase, IDisposable
 
     /// <summary>Called when restricted modes are automatically unselected on queue. Set by the parent VM.</summary>
     public Action? ShowRestrictedModesRemovedToast { get; set; }
+
+    /// <summary>Called when the queue button should install a pending game update instead of searching.</summary>
+    public Action? InstallPendingGameUpdate { get; set; }
 
     public QueueViewModel(IQueueSocketService queueSocketService, IBackendApiService backendApiService, ISettingsStorage settingsStorage, ITriviaRepository triviaRepository, ITimerFactory timerFactory)
     {
@@ -119,8 +128,16 @@ public partial class QueueViewModel : ViewModelBase, IDisposable
             UpdateQueueButtonState();
         });
 
+    partial void OnIsGameUpdatePendingChanged(bool value) => UpdateQueueButtonState();
+
     public async Task ToggleSearchAsync()
     {
+        if (IsGameUpdatePending)
+        {
+            InstallPendingGameUpdate?.Invoke();
+            return;
+        }
+
         if (IsSearching)
         {
             var cancelModesStr = _queuedModes != null
@@ -298,7 +315,13 @@ public partial class QueueViewModel : ViewModelBase, IDisposable
 
     public void UpdateQueueButtonState()
     {
-        if (_hasServerUrl)
+        if (IsGameUpdatePending)
+        {
+            QueueButtonMainText = I18n.T("game.updateGame");
+            QueueButtonModeCountText = "";
+            QueueButtonTimeText = "";
+        }
+        else if (_hasServerUrl)
         {
             QueueButtonMainText = Strings.Connect;
             QueueButtonModeCountText = "";

--- a/ViewModels/QueueViewModel.cs
+++ b/ViewModels/QueueViewModel.cs
@@ -69,18 +69,18 @@ public partial class QueueViewModel : ViewModelBase, IDisposable
     private string _searchingInQueueText = "";
 
     /// <summary>Blue when game ready, green when searching, dark gray when idle.</summary>
-    public IBrush QueueButtonBackground => IsGameUpdatePending ? BrushReady
-        : _hasServerUrl ? BrushReady
+    public IBrush QueueButtonBackground => _hasServerUrl ? BrushReady
+        : IsGameUpdatePending ? BrushReady
         : IsSearching ? BrushSearching : BrushIdle;
 
     /// <summary>Lighter version for hover state.</summary>
-    public IBrush QueueButtonHoverBackground => IsGameUpdatePending ? BrushReadyHover
-        : _hasServerUrl ? BrushReadyHover
+    public IBrush QueueButtonHoverBackground => _hasServerUrl ? BrushReadyHover
+        : IsGameUpdatePending ? BrushReadyHover
         : IsSearching ? BrushSearchingHover : BrushIdleHover;
 
     /// <summary>Subtle lighter border to give the button a framed look.</summary>
-    public IBrush QueueButtonBorderBrush => IsGameUpdatePending ? BrushBorderReady
-        : _hasServerUrl ? BrushBorderReady
+    public IBrush QueueButtonBorderBrush => _hasServerUrl ? BrushBorderReady
+        : IsGameUpdatePending ? BrushBorderReady
         : IsSearching ? BrushBorderSearching : BrushBorderIdle;
 
     /// <summary>Called when the user presses queue with no modes selected. Set by the parent VM.</summary>
@@ -315,15 +315,15 @@ public partial class QueueViewModel : ViewModelBase, IDisposable
 
     public void UpdateQueueButtonState()
     {
-        if (IsGameUpdatePending)
+        if (_hasServerUrl)
         {
-            QueueButtonMainText = I18n.T("game.updateGame");
+            QueueButtonMainText = Strings.Connect;
             QueueButtonModeCountText = "";
             QueueButtonTimeText = "";
         }
-        else if (_hasServerUrl)
+        else if (IsGameUpdatePending)
         {
-            QueueButtonMainText = Strings.Connect;
+            QueueButtonMainText = I18n.T("game.updateGame");
             QueueButtonModeCountText = "";
             QueueButtonTimeText = "";
         }

--- a/ViewModels/QueueViewModel.cs
+++ b/ViewModels/QueueViewModel.cs
@@ -119,7 +119,7 @@ public partial class QueueViewModel : ViewModelBase, IDisposable
         Dispatcher.UIThread.Post(() => UpdateQueueCounts(msg));
 
     private void OnPlayerQueueStateUpdated(PlayerQueueStateMessage msg) =>
-        Dispatcher.UIThread.Post(async () => await UpdatePlayerQueueState(msg));
+        Dispatcher.UIThread.Post(() => UpdatePlayerQueueState(msg).FireAndForget("UpdatePlayerQueueState"));
 
     private void OnPlayerGameStateUpdated(PlayerGameStateMessage? msg) =>
         Dispatcher.UIThread.Post(() =>

--- a/Views/Components/LauncherHeader.axaml
+++ b/Views/Components/LauncherHeader.axaml
@@ -150,6 +150,7 @@
       <StackPanel Grid.Column="2" Orientation="Horizontal">
         <Button x:Name="LaunchGameButton" VerticalAlignment="Center" Margin="0,0,6,0"
                 Padding="12,6" CornerRadius="2" Cursor="Hand"
+                IsEnabled="{Binding Launch.IsPlayButtonEnabled}"
                 Click="OnLaunchGameClicked"
                 Classes.stop="{Binding Launch.PlayButtonIsStop}"
                 BorderThickness="1">
@@ -195,16 +196,12 @@
           <StackPanel Orientation="Horizontal" Spacing="6">
             <materialIcons:MaterialIcon Kind="PlayArrow" Width="16" Height="16"
                                         VerticalAlignment="Center"
-                                        IsVisible="{Binding !Launch.PlayButtonIsStop}"/>
+                                        IsVisible="{Binding Launch.ShowPlayButtonIcon}"/>
             <materialIcons:MaterialIcon Kind="Stop" Width="14" Height="14"
                                         VerticalAlignment="Center"
                                         IsVisible="{Binding Launch.PlayButtonIsStop}"/>
-            <TextBlock Text="{x:Static res:Strings.Play}" FontSize="{DynamicResource FontSizeBase}"
-                       FontWeight="SemiBold" LetterSpacing="1" VerticalAlignment="Center"
-                       IsVisible="{Binding !Launch.PlayButtonIsStop}"/>
-            <TextBlock Text="{x:Static res:Strings.Stop}" FontSize="{DynamicResource FontSizeBase}"
-                       FontWeight="SemiBold" LetterSpacing="1" VerticalAlignment="Center"
-                       IsVisible="{Binding Launch.PlayButtonIsStop}"/>
+            <TextBlock Text="{Binding Launch.PlayButtonText}" FontSize="{DynamicResource FontSizeBase}"
+                       FontWeight="SemiBold" LetterSpacing="1" VerticalAlignment="Center"/>
           </StackPanel>
         </Button>
         <Button x:Name="SettingsButton" VerticalAlignment="Stretch" Padding="10,8"

--- a/Views/MainLauncherView.axaml
+++ b/Views/MainLauncherView.axaml
@@ -139,6 +139,32 @@
                </Border>
            </Panel>
 
+           <!-- Game update prompt -->
+           <Panel IsVisible="{Binding IsGameUpdatePromptOpen}" ZIndex="220"
+                  HorizontalAlignment="Stretch" VerticalAlignment="Stretch" Background="#90000000">
+               <Border HorizontalAlignment="Center" VerticalAlignment="Center"
+                       Width="420"
+                       Padding="28,24" CornerRadius="0"
+                       Background="#121315" BorderBrush="#2d3842" BorderThickness="1"
+                       BoxShadow="0 12 28 0 #80000000">
+                   <StackPanel Spacing="20">
+                       <TextBlock Text="{l:T 'game.updatePromptTitle'}" FontSize="{DynamicResource FontSize2XL}" FontWeight="Bold"
+                                  HorizontalAlignment="Center" Foreground="#D9D9D9"/>
+                       <TextBlock Text="{Binding GameUpdatePromptText}"
+                                  HorizontalAlignment="Center" TextAlignment="Center" TextWrapping="Wrap"
+                                  Foreground="#AAAAAA" FontSize="{DynamicResource FontSizeMD}"/>
+                       <StackPanel Orientation="Horizontal" HorizontalAlignment="Center" Spacing="12">
+                           <Button Classes="PrimaryButton"
+                                   Content="{l:T 'game.installUpdate'}" Command="{Binding InstallGameUpdateCommand}"
+                                   Padding="28,10" CornerRadius="0"/>
+                           <Button Classes="DangerButton"
+                                   Content="{x:Static res:Strings.Cancel}" Command="{Binding DismissGameUpdatePromptCommand}"
+                                   Padding="28,10" CornerRadius="0"/>
+                       </StackPanel>
+                   </StackPanel>
+               </Border>
+           </Panel>
+
            <!-- Floating party invite notifications (top-right) -->
            <components:NotificationArea DataContext="{Binding NotificationArea}"
                                         ZIndex="150"

--- a/Views/MainWindow.axaml.cs
+++ b/Views/MainWindow.axaml.cs
@@ -29,10 +29,16 @@ public partial class MainWindow : Window
     protected override void OnKeyDown(KeyEventArgs e)
     {
         base.OnKeyDown(e);
-        if (e.Key == Key.F4 &&
-            DataContext is MainWindowViewModel { CurrentContentViewModel: MainLauncherViewModel launcher })
+        if (DataContext is not MainWindowViewModel { CurrentContentViewModel: MainLauncherViewModel launcher })
+            return;
+
+        if (e.Key == Key.F4)
         {
             launcher.TriggerDevAchievementNotification();
+        }
+        else if (e.Key == Key.F5)
+        {
+            launcher.ToggleDevGameUpdatePending();
         }
     }
 

--- a/d2c-launcher.Tests/QueueSocketServiceTests.cs
+++ b/d2c-launcher.Tests/QueueSocketServiceTests.cs
@@ -64,6 +64,47 @@ public sealed class QueueSocketServiceTests
         Assert.True(factory.Socket.Connected);
     }
 
+    // ── ReconnectAsync ────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task ReconnectAsync_after_natural_drop_reconnects()
+    {
+        var (svc, f) = Build();
+        await svc.ConnectAsync("token");
+        f.Socket.SimulateDisconnect(); // network drop — token still held
+
+        await svc.ReconnectAsync();
+
+        Assert.True(f.Socket.Connected);
+        Assert.Equal(GameCoordinatorState.Connected, svc.State);
+    }
+
+    [Fact]
+    public async Task ReconnectAsync_while_connected_disconnects_then_reconnects()
+    {
+        var (svc, f) = Build();
+        await svc.ConnectAsync("token");
+
+        var disconnects = 0;
+        f.Socket.OnDisconnected += (_, _) => disconnects++;
+
+        await svc.ReconnectAsync();
+
+        Assert.Equal(1, disconnects);
+        Assert.True(f.Socket.Connected);
+    }
+
+    [Fact]
+    public async Task ReconnectAsync_without_prior_connect_is_no_op()
+    {
+        var (svc, f) = Build();
+
+        await svc.ReconnectAsync(); // never connected, no token stored
+
+        Assert.False(f.Socket.Connected);
+        Assert.Equal(GameCoordinatorState.Disconnected, svc.State);
+    }
+
     // ── Emit guards ───────────────────────────────────────────────────────────
 
     [Fact]

--- a/memory-bank/activeContext.md
+++ b/memory-bank/activeContext.md
@@ -2,7 +2,7 @@
 
 ## Current State
 
-All major features are shipped. The launcher is in maintenance/polish mode. Working on #69 (Windows auto-launch on login, hidden tray startup, and throttled background verification).
+All major features are shipped. The launcher is in maintenance/polish mode. Working on #167 (detect remote game updates while launcher stays open, gate launch until update installs, and prompt the user to install immediately).
 
 Repository AI workflow files now use a shared `.agents/` layout. `.agents/commands/` and `.agents/agents/` are the canonical copies, Codex picks up wrappers from `.agents/skills/`, and `.claude/commands` plus `.claude/agents` are directory junctions that preserve Claude compatibility without duplicating prompt files.
 
@@ -48,6 +48,7 @@ Repository AI workflow files now use a shared `.agents/` layout. `.agents/comman
 | #155 | Matchmaking Windows toasts — hidden launcher now shows actionable native toasts for party invites and ready checks; toast buttons route through `d2c://party-invite/...` and `d2c://ready-check/...`; `WindowService` preserves `WindowShown` after eager visibility updates |
 | #155 follow-up | Activation-path cleanup refined — `App.axaml.cs` now keeps normal protocol launches foregrounding the launcher, preserves forwarded `-ToastActivated` restore behavior, restores the launcher for positive toast actions (`accept`, `enter queue`, `d2c://game`), and leaves negative actions like `decline` in the background |
 | #169 | Ready-check decline false positive — backend now sends explicit `PLAYER_DECLINE_GAME` socket events with `reason=DECLINED|TIMEOUT`; `QueueSocketService` forwards that payload and `RoomViewModel` now shows the local timeout modal only for `TIMEOUT`, while `DECLINED` just closes the ready-check UI and returns to matchmaking without any heuristic queue-state delay |
+| #167 | Remote game updates while launcher stays open — `GameDownloadViewModel` now reports a combined verified manifest snapshot back to `MainWindowViewModel`; the root VM polls remote manifests every 3 minutes without rescanning disk, compares them against that in-memory snapshot, and marks `update pending` when remote files diverge. Launch is gated in `GameLaunchViewModel`, the Play-tab queue/search button now switches to `ОБНОВИТЬ ИГРУ` and starts install instead of queueing, `MainLauncherView` shows an install-now modal, hidden/inactive launcher windows receive a one-shot native Windows toast when an update first becomes pending, and all install-update entry points now converge on one path that stops Dota, leaves all queues, and then re-enters verification |
 
 ## Next Steps / Open Issues
 
@@ -79,3 +80,4 @@ Repository AI workflow files now use a shared `.agents/` layout. `.agents/comman
 - **Settings sub-VMs:** Gameplay/video cvars → `GameSettingsViewModel`; launcher prefs → `LauncherPrefsViewModel`. `SettingsViewModel` is a thin container.
 - **Game mode default:** Mode ID 7 (Bots). Mode 12 no longer exists.
 - **Preview tool:** Run `powershell -ExecutionPolicy Bypass -File tools/preview.ps1 <Name>` — always use `Read` on the screenshot to verify before declaring done.
+- **Remote game updates:** Keep the verified local manifest snapshot only in memory for the current session. Periodic update detection compares fresh remote manifests against that snapshot; it must not rescan local files on every poll.

--- a/memory-bank/docs/game-update-polling.md
+++ b/memory-bank/docs/game-update-polling.md
@@ -1,0 +1,47 @@
+# Game Update Polling
+
+## Overview
+
+Issue #167 adds update detection while the launcher stays open.
+
+The launcher now keeps an in-memory verified manifest snapshot for the active game directory and compares it against fresh remote manifests on a timer. This avoids rescanning local files repeatedly.
+
+## Baseline Snapshot
+
+`MainWindowViewModel` owns the current verified local baseline for the session.
+
+- `GameDownloadViewModel` fetches the selected remote package manifests during normal verification.
+- After a successful verification/download, it reports the combined remote manifest back to `MainWindowViewModel`.
+- That combined manifest becomes the in-memory installed snapshot.
+
+The snapshot is not persisted to disk. It only lives for the current launcher session.
+
+## Periodic Check Flow
+
+`MainWindowViewModel` starts a timer once verification has succeeded, the app is back in `AppState.Launcher`, and a verified snapshot exists.
+
+On each poll:
+
+1. Fetch the latest selected package manifests from CDN.
+2. Combine them into one remote manifest.
+3. Diff remote vs. the in-memory snapshot with `ManifestDiffService`.
+4. If any files would need downloading, mark `update pending`.
+
+No local disk scan happens during this timer-based check.
+
+## UI Behavior
+
+When a remote update is detected:
+
+- `MainLauncherViewModel` sets `IsGameUpdatePending`.
+- `GameLaunchViewModel` disables normal launch from idle state and changes the button text to `Обновить`.
+- `MainLauncherView` shows a modal asking the user to install the update.
+- If Dota is currently running and the user accepts, the launcher stops the game first and then enters the normal verification/download flow.
+
+If verification succeeds again, the snapshot is replaced and the pending-update state is cleared.
+
+## Shared Remote Manifest Loading
+
+Remote CDN manifest loading now lives in `IRemoteManifestService` / `RemoteManifestService` instead of being embedded directly in `GameDownloadViewModel`.
+
+This keeps foreground/background verification and periodic remote-only update polling on the same code path.

--- a/memory-bank/progress.md
+++ b/memory-bank/progress.md
@@ -38,6 +38,7 @@
 | --------------------------------- | ------ | ---------------------------------- |
 | Game directory validation         | ✅ Done |                                    |
 | Game download / verify on launch  | ✅ Done | `GameDownloadView`, manifest diff, HTTP download |
+| Remote update detection while launcher stays open (issue #167) | ✅ Done | `MainWindowViewModel` keeps an in-memory verified manifest snapshot, polls fresh remote manifests every 3 minutes, diffs remote vs. cached local baseline, disables idle launch via `GameLaunchViewModel`, prompts to install immediately, and shows a one-shot native Windows toast when an update first becomes pending while the launcher window is hidden/inactive; no periodic local file rescans |
 | HDD scan optimization (issue #9)  | ✅ Done | mtime+size hash cache + WMI SSD detection for parallelism; issue #159 fixed the storage lookup with a hybrid strategy: `MSFT_PhysicalDisk.DeviceId == Win32_DiskDrive.Index` first, then `MSFT_StorageNodeToPhysicalDisk.DiskNumber` -> `MSFT_PhysicalDisk.MediaType` as a fallback, so tested SSD installs no longer fall back to sequential `HDD/unknown` |
 | Scan duration metric to Faro (issue #10) | ✅ Done | `TrackEvent("scan_completed")` with `duration_ms` + `file_count` |
 | Redist install after verify (issue #6) | ✅ Done | `RedistInstallService` — runs `_CommonRedist` DirectX + vcredist silently once per game dir |
@@ -198,6 +199,7 @@ Other known technical debt:
 | `memory-bank/docs/source-engine-config-persistence.md` | ✅ Written |
 | `memory-bank/docs/settings-architecture.md` | ✅ Written |
 | `memory-bank/docs/game-update-manifest.md` | ✅ Written |
+| `memory-bank/docs/game-update-polling.md` | ✅ Written |
 | `memory-bank/docs/client-dll-patching.md` | ✅ Written — patching done server-side (CDN); enables `dota_camera_distance` cvar; released |
 | Memory bank (`memory-bank/`) | ✅ Written |
 
@@ -214,3 +216,4 @@ Other known technical debt:
 
 - Background-start verification failures are now observable: `GameDownloadViewModel` logs `[GameDownload]` errors and emits Faro `verification_failed` telemetry.
 - Protocol-triggered pre-verification routing now marshals back onto the UI thread before changing `MainWindowViewModel` state.
+- Issue #167 follow-up: all "install update" entry points now share one path in `MainLauncherViewModel` that always stops Dota, leaves all queues, and then starts verification; `GameLaunchViewModel.PlayButtonIsStop` again reflects actual run state so the header stop/update behavior stays consistent while an update is pending.


### PR DESCRIPTION
## Summary
- add `IRemoteManifestService` so verification and periodic remote-only checks share the same manifest loading path
- keep a verified in-memory manifest snapshot in `MainWindowViewModel`, poll remote manifests every 3 minutes, and mark the launcher as update-pending when CDN files diverge
- gate idle launch/search behind update install flow, show an in-app modal plus a one-shot Windows toast, and document the polling design in the memory bank

## Testing
- `dotnet build`
- `dotnet test d2c-launcher.Tests`