### PR TITLE
fix: use auth token for player search and show friends when no query

### DIFF
--- a/Preview/PreviewStubs.cs
+++ b/Preview/PreviewStubs.cs
@@ -89,6 +89,9 @@ internal sealed class StubBackendApiService : IBackendApiService
     public Task<IReadOnlyList<InviteCandidateView>> SearchPlayersAsync(string name, int count = 25, CancellationToken cancellationToken = default)
         => Task.FromResult<IReadOnlyList<InviteCandidateView>>([]);
 
+    public Task<IReadOnlyList<InviteCandidateView>> GetFriendsAsync(CancellationToken cancellationToken = default)
+        => Task.FromResult<IReadOnlyList<InviteCandidateView>>([]);
+
     public Task<(string? Name, string? AvatarUrl)?> GetUserInfoAsync(string steamId, CancellationToken cancellationToken = default)
         => Task.FromResult<(string?, string?)?>(null);
 

--- a/Services/BackendApiService.cs
+++ b/Services/BackendApiService.cs
@@ -159,7 +159,7 @@ public sealed class BackendApiService : IBackendApiService, IDisposable
             return Array.Empty<InviteCandidateView>();
 
         AppLog.Info($"Searching players: name='{name}', count={count}");
-        var api = new DotaclassicApiClient(_httpClient);
+        var api = new DotaclassicApiClient(_authHttpClient);
         var users = await api.PlayerController_searchAsync(name, count, cancellationToken);
         if (users == null)
             return Array.Empty<InviteCandidateView>();
@@ -184,6 +184,44 @@ public sealed class BackendApiService : IBackendApiService, IDisposable
 
         AppLog.Info($"Search returned {result.Count} players.");
         return result;
+    }
+
+    public async Task<IReadOnlyList<InviteCandidateView>> GetFriendsAsync(CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(_currentToken))
+            return Array.Empty<InviteCandidateView>();
+
+        try
+        {
+            AppLog.Info("Loading friends for invite candidates.");
+            var api = new DotaclassicApiClient(_authHttpClient);
+            var users = await api.PlayerController_getFriendsAsync(cancellationToken).ConfigureAwait(false);
+            if (users == null)
+                return Array.Empty<InviteCandidateView>();
+
+            var result = new List<InviteCandidateView>(users.Count);
+            foreach (var user in users)
+            {
+                if (user == null || string.IsNullOrWhiteSpace(user.SteamId))
+                    continue;
+
+                var displayName = !string.IsNullOrWhiteSpace(user.Name) ? user.Name : user.SteamId;
+                if (string.IsNullOrWhiteSpace(displayName))
+                    continue;
+
+                var initials = GetInitials(displayName);
+                var avatarUrl = user.AvatarSmall ?? user.Avatar;
+                result.Add(new InviteCandidateView(user.SteamId, displayName, initials, false, avatarUrl));
+            }
+
+            AppLog.Info($"Loaded {result.Count} friends.");
+            return result;
+        }
+        catch (Exception ex)
+        {
+            AppLog.Error($"GetFriendsAsync failed: {ex.Message}", ex);
+            return Array.Empty<InviteCandidateView>();
+        }
     }
 
     public async Task<(string? Name, string? AvatarUrl)?> GetUserInfoAsync(string steamId, CancellationToken cancellationToken = default)

--- a/Services/IBackendApiService.cs
+++ b/Services/IBackendApiService.cs
@@ -16,6 +16,8 @@ public interface IBackendApiService
     /// <summary>Returns labels for all matchmaking modes, including disabled ones. Used by the Live panel.</summary>
     Task<IReadOnlyList<MatchmakingModeInfo>> GetAllMatchmakingModesAsync(CancellationToken cancellationToken = default);
     Task<IReadOnlyList<InviteCandidateView>> SearchPlayersAsync(string name, int count = 25, CancellationToken cancellationToken = default);
+    /// <summary>Returns the authenticated user's friends list for use as initial invite candidates.</summary>
+    Task<IReadOnlyList<InviteCandidateView>> GetFriendsAsync(CancellationToken cancellationToken = default);
     Task<(string? Name, string? AvatarUrl)?> GetUserInfoAsync(string steamId, CancellationToken cancellationToken = default);
     Task<(int InGame, int OnSite)> GetOnlineStatsAsync(CancellationToken cancellationToken = default);
     Task<IReadOnlyList<ChatMessageData>> GetChatMessagesAsync(string threadId, int limit, CancellationToken cancellationToken = default);

--- a/ViewModels/PartyViewModel.cs
+++ b/ViewModels/PartyViewModel.cs
@@ -214,8 +214,8 @@ public partial class PartyViewModel : ViewModelBase, IDisposable
             return;
         try
         {
-            AppLog.Info("Loading initial invite candidates.");
-            var results = await _backendApiService.SearchPlayersAsync("a", 10);
+            AppLog.Info("Loading initial invite candidates (friends).");
+            var results = await _backendApiService.GetFriendsAsync();
             Dispatcher.UIThread.Post(() =>
             {
                 InviteCandidates = new ObservableCollection<InviteCandidateView>(results);


### PR DESCRIPTION
## Summary

- `SearchPlayersAsync` was using the unauthenticated `_httpClient`, so the server had no way to identify the caller and could not sort friends first in results
- `LoadInitialInviteCandidatesAsync` worked around the empty-query guard by searching for `"a"` instead of fetching the user's friends
- Added `GetFriendsAsync()` backed by `v1/player/friends` (authenticated); the invite modal now shows the caller's friends when no search text is typed

## Test plan

- [ ] Open invite modal with no text — friends list appears
- [ ] Type a name — search results appear (with friends sorted first by server)
- [ ] Repeat with no friends — empty list shown correctly

Closes #174