### PR TITLE
fix: replace star fallback with d2c logo for subscriber chat icon

### DIFF
--- a/Preview/PreviewStubs.cs
+++ b/Preview/PreviewStubs.cs
@@ -106,6 +106,7 @@ internal sealed class StubBackendApiService : IBackendApiService
             new ChatMessageData("4", threadId, "если он есть", "2025-03-05T20:05:20Z", "222", "лоутаб секьюрити", null, false),
             new ChatMessageData("5", threadId, "геге, мормышка победил", "2025-03-05T20:10:00Z", "111", "MaxiKo", null, false),
             new ChatMessageData("6", threadId, "играю сносно https://dotaclassic.ru/players/198768255 але", "2025-03-05T20:11:00Z", "222", "лоутаб секьюрити", null, false),
+            new ChatMessageData("7", threadId, "я подписчик!", "2025-03-05T20:12:00Z", "333", "subscriber_user", null, false, IsOld: true),
         ]);
 
     public Task PostChatMessageAsync(string threadId, string content, string? replyMessageId = null, CancellationToken cancellationToken = default)

--- a/Views/Components/ChatPanel.axaml
+++ b/Views/Components/ChatPanel.axaml
@@ -155,7 +155,7 @@
                                                                                 Foreground="#9E9E9E"
                                                                                 IsVisible="{Binding IsAdmin}"
                                                                                 ToolTip.Tip="{util:T 'chat.roleAdminTooltip'}"/>
-                                                    <!-- OLD subscriber: custom chat icon (GIF-capable) or star fallback; click opens store -->
+                                                    <!-- OLD subscriber: custom chat icon (GIF-capable) or d2c logo fallback; click opens store -->
                                                     <Button IsVisible="{Binding IsOld}"
                                                             Width="16" Height="16"
                                                             Padding="0"
@@ -174,12 +174,11 @@
                                                             <components:EmoticonImage
                                                                 Bytes="{Binding ChatIconBytes}"
                                                                 Width="16" Height="16"/>
-                                                            <materialIcons:MaterialIcon Kind="Star"
-                                                                                        Width="14" Height="14"
-                                                                                        Foreground="#FFD700"
-                                                                                        HorizontalAlignment="Center"
-                                                                                        VerticalAlignment="Center"
-                                                                                        IsVisible="{Binding ChatIconBytes, Converter={x:Static ObjectConverters.IsNull}}"/>
+                                                            <Image Source="avares://d2c-launcher/Assets/icon.ico"
+                                                                   Width="14" Height="14"
+                                                                   HorizontalAlignment="Center"
+                                                                   VerticalAlignment="Center"
+                                                                   IsVisible="{Binding ChatIconBytes, Converter={x:Static ObjectConverters.IsNull}}"/>
                                                         </Panel>
                                                     </Button>
                                                 </StackPanel>

--- a/memory-bank/activeContext.md
+++ b/memory-bank/activeContext.md
@@ -12,6 +12,7 @@ Repository AI workflow files use a shared `.agents/` layout. `.agents/commands/`
 
 | Issue | What was done |
 |-------|--------------|
+| #168 | Chat subscriber icon: replaced star fallback with d2c logo (`icon.ico`) |
 | #177 | Subscription tab in profile — dodge list + Plus subscription status, owner-only |
 | #176 | Notification sound volume setting |
 | #172 | Detect pending remote game updates (#167 follow-up) |


### PR DESCRIPTION
## Summary

- Subscribers without a custom chat icon were showing a gold star (`MaterialIcon Kind="Star"`) next to their name in chat
- Replace the star fallback with `avares://d2c-launcher/Assets/icon.ico` (the d2c logo), matching the expected behavior
- Also adds an `IsOld: true` stub message to the ChatPanel preview so the icon is visible during development

## Test plan
- [ ] Open chat — a Dotaclassic Plus subscriber without a custom icon should display the d2c fox logo, not a star
- [ ] A subscriber with a custom `ChatIconUrl` should still show their custom animated icon (unchanged path)
- [ ] All 301 tests pass

Closes #168