### PR TITLE
feat: show pinned message at top of chat

### DIFF
--- a/Preview/PreviewStubs.cs
+++ b/Preview/PreviewStubs.cs
@@ -142,6 +142,12 @@ internal sealed class StubBackendApiService : IBackendApiService
     public Task AcknowledgeNotificationAsync(string notificationId, CancellationToken cancellationToken = default) => Task.CompletedTask;
     public Task<IReadOnlyList<Models.ChatReactionData>> ReactToMessageAsync(string messageId, int emoticonId, CancellationToken cancellationToken = default)
         => Task.FromResult<IReadOnlyList<Models.ChatReactionData>>(Array.Empty<Models.ChatReactionData>());
+
+    public Task<ChatMessageData?> GetPinnedMessageAsync(string threadId, CancellationToken cancellationToken = default)
+        => Task.FromResult<ChatMessageData?>(new ChatMessageData(
+            "pinned-1", threadId,
+            "🚀 30 апреля в 17:00 (МСК) — глобальное обновление DOTACLASSIC: новый патч, переработка Techies 🔨, обновлённый сайт и лаунчер. 🏴",
+            "2026-04-23T14:34:00Z", "111", "egor_lib", null, false));
     public Task<IReadOnlyList<d2c_launcher.Api.NotificationDto>> GetNotificationsAsync(CancellationToken cancellationToken = default)
         => Task.FromResult<IReadOnlyList<d2c_launcher.Api.NotificationDto>>(Array.Empty<d2c_launcher.Api.NotificationDto>());
 

--- a/Resources/Locales/ru.json
+++ b/Resources/Locales/ru.json
@@ -284,7 +284,8 @@
     "reply": "Ответить",
     "replyingTo": "В ответ",
     "cancelReply": "Отмена",
-    "todayAt": "Сегодня в {time}"
+    "todayAt": "Сегодня в {time}",
+    "pinned": "Закреплено"
   },
   "download": {
     "downloadGame": "Скачать игру",

--- a/Services/BackendApiService.cs
+++ b/Services/BackendApiService.cs
@@ -295,26 +295,39 @@ public sealed class BackendApiService : IBackendApiService, IDisposable
         {
             if (msg == null || msg.Deleted)
                 continue;
-            result.Add(new ChatMessageData(
-                msg.MessageId,
-                msg.ThreadId,
-                msg.Content,
-                msg.CreatedAt,
-                msg.Author?.SteamId ?? "",
-                msg.Author?.Name ?? "",
-                msg.Author?.AvatarSmall ?? msg.Author?.Avatar,
-                msg.Deleted,
-                msg.Reply?.Author?.Name,
-                msg.Reply?.Content,
-                MapReactions(msg.Reactions),
-                IsOld: HasRole(msg.Author, Api.Role.OLD),
-                IsModerator: HasRole(msg.Author, Api.Role.MODERATOR),
-                IsAdmin: HasRole(msg.Author, Api.Role.ADMIN),
-                ChatIconUrl: msg.Author?.Icon?.Image?.Url,
-                ChatIconTitle: msg.Author?.Title?.Title));
+            result.Add(MapThreadMessage(msg));
         }
         return result;
     }
+
+    public async Task<ChatMessageData?> GetPinnedMessageAsync(
+        string threadId, CancellationToken cancellationToken = default)
+    {
+        var api = new DotaclassicApiClient(_authHttpClient);
+        var thread = await api.ForumController_getThreadAsync(
+            threadId, Api.ThreadType.Forum, cancellationToken).ConfigureAwait(false);
+        var msg = thread?.PinnedMessage;
+        if (msg == null || msg.Deleted) return null;
+        return MapThreadMessage(msg);
+    }
+
+    private static ChatMessageData MapThreadMessage(Api.ThreadMessageDTO msg) => new(
+        msg.MessageId,
+        msg.ThreadId,
+        msg.Content,
+        msg.CreatedAt,
+        msg.Author?.SteamId ?? "",
+        msg.Author?.Name ?? "",
+        msg.Author?.AvatarSmall ?? msg.Author?.Avatar,
+        msg.Deleted,
+        msg.Reply?.Author?.Name,
+        msg.Reply?.Content,
+        MapReactions(msg.Reactions),
+        IsOld: HasRole(msg.Author, Api.Role.OLD),
+        IsModerator: HasRole(msg.Author, Api.Role.MODERATOR),
+        IsAdmin: HasRole(msg.Author, Api.Role.ADMIN),
+        ChatIconUrl: msg.Author?.Icon?.Image?.Url,
+        ChatIconTitle: msg.Author?.Title?.Title);
 
     public async Task PostChatMessageAsync(
         string threadId, string content, string? replyMessageId = null, CancellationToken cancellationToken = default)

--- a/Services/IBackendApiService.cs
+++ b/Services/IBackendApiService.cs
@@ -37,6 +37,8 @@ public interface IBackendApiService
     Task<IReadOnlyList<d2c_launcher.Api.NotificationDto>> GetNotificationsAsync(CancellationToken cancellationToken = default);
     /// <summary>Toggles the reaction with <paramref name="emoticonId"/> on a message. Returns the updated reactions.</summary>
     Task<IReadOnlyList<ChatReactionData>> ReactToMessageAsync(string messageId, int emoticonId, CancellationToken cancellationToken = default);
+    /// <summary>Returns the pinned message for <paramref name="threadId"/>, or null if none is pinned.</summary>
+    Task<ChatMessageData?> GetPinnedMessageAsync(string threadId, CancellationToken cancellationToken = default);
     /// <summary>Returns all currently live Twitch streams for the community.</summary>
     Task<IReadOnlyList<d2c_launcher.Api.TwitchStreamDto>> GetTwitchStreamsAsync(CancellationToken cancellationToken = default);
     /// <summary>Returns the current authenticated user's profile, including role/subscription data.</summary>

--- a/ViewModels/ChatViewModel.cs
+++ b/ViewModels/ChatViewModel.cs
@@ -216,6 +216,16 @@ public partial class ChatViewModel : ViewModelBase, IDisposable
                 return;
             }
 
+            // Update pinned message in-place; do not append it to the message list.
+            if (PinnedMessage?.MessageId == msg.MessageId)
+            {
+                PinnedMessage.Content = msg.Content;
+                PinnedMessage.RichContent = RichMessageParser.Parse(msg.Content, _emoticonSnapshot.Images, _userNameResolver.GetOrCreate);
+                if (msg.Reactions != null)
+                    PinnedMessage.UpdateReactions(msg.Reactions, data => BuildReactionVm(msg.MessageId, data));
+                return;
+            }
+
             var prevEntry = _lastMessageRaw == null ? null
                 : new ChatEntry(_lastMessageRaw.Value.AuthorSteamId, _lastMessageRaw.Value.CreatedAt);
             var showHeader = ChatGrouper.ShouldShowHeader(prevEntry, new ChatEntry(msg.AuthorSteamId, msg.CreatedAt));
@@ -448,7 +458,8 @@ public partial class ChatViewModel : ViewModelBase, IDisposable
 
             _dispatcher.Post(() =>
             {
-                var view = Messages.FirstOrDefault(m => m.MessageId == messageId);
+                var view = Messages.FirstOrDefault(m => m.MessageId == messageId)
+                           ?? (PinnedMessage?.MessageId == messageId ? PinnedMessage : null);
                 view?.UpdateReactions(updatedReactions, data => BuildReactionVm(messageId, data));
             });
         }

--- a/ViewModels/ChatViewModel.cs
+++ b/ViewModels/ChatViewModel.cs
@@ -40,6 +40,7 @@ public partial class ChatViewModel : ViewModelBase, IDisposable
     [ObservableProperty] private string _inputText = "";
     [ObservableProperty] private bool _isLoading;
     [ObservableProperty] private bool _isSending;
+    [ObservableProperty] private ChatMessageView? _pinnedMessage;
 
     [ObservableProperty] private bool _isReplying;
     [ObservableProperty] private string? _replyTargetId;
@@ -87,6 +88,7 @@ public partial class ChatViewModel : ViewModelBase, IDisposable
     private void OnWindowShown()
     {
         _ = RefreshAsync();
+        _ = RefreshPinnedMessageAsync();
         _messageStream.Restart();
     }
 
@@ -94,7 +96,8 @@ public partial class ChatViewModel : ViewModelBase, IDisposable
     {
         // Emoticons finished loading — re-parse, wire quick-reacts, and patch reaction icons in one pass.
         // Already on the UI thread (EmoticonSnapshotBuilder fires via IUiDispatcher).
-        foreach (var msg in Messages)
+        var allMessages = PinnedMessage == null ? (IEnumerable<ChatMessageView>)Messages : Messages.Prepend(PinnedMessage);
+        foreach (var msg in allMessages)
         {
             msg.RichContent = RichMessageParser.Parse(msg.Content, _emoticonSnapshot.Images, _userNameResolver.GetOrCreate);
             SetupQuickReacts(msg);
@@ -123,7 +126,46 @@ public partial class ChatViewModel : ViewModelBase, IDisposable
         // Load emoticons in the background — don't block message loading.
         _ = _emoticonSnapshot.EnsureLoadedAsync();
         await RefreshAsync().ConfigureAwait(false);
+        _ = RefreshPinnedMessageAsync();
         _messageStream.Start();
+    }
+
+    private async Task RefreshPinnedMessageAsync(CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            var data = await _backendApiService.GetPinnedMessageAsync(_threadId, cancellationToken).ConfigureAwait(false);
+            _dispatcher.Post(() =>
+            {
+                if (data == null)
+                {
+                    PinnedMessage = null;
+                    return;
+                }
+                var richContent = RichMessageParser.Parse(data.Content, _emoticonSnapshot.Images, _userNameResolver.GetOrCreate);
+                var view = new ChatMessageView(
+                    data.MessageId, data.Content, richContent,
+                    data.AuthorName, data.AuthorSteamId,
+                    showHeader: true,
+                    FormatTime(ParseDate(data.CreatedAt)),
+                    data.CreatedAt,
+                    data.AuthorAvatarUrl,
+                    data.ReplyToAuthorName, data.ReplyToContent,
+                    data.IsOld, data.IsModerator, data.IsAdmin,
+                    data.ChatIconTitle);
+                if (data.Reactions != null)
+                    view.UpdateReactions(data.Reactions, r => BuildReactionVm(data.MessageId, r));
+                SetupQuickReacts(view);
+                if (data.IsOld && data.ChatIconUrl != null)
+                    _ = LoadChatIconAsync(view, data.ChatIconUrl);
+                PinnedMessage = view;
+            });
+        }
+        catch (OperationCanceledException) { }
+        catch (Exception ex)
+        {
+            AppLog.Error($"Chat: failed to load pinned message: {ex.Message}", ex);
+        }
     }
 
     /// <summary>Cancels the current SSE connection and reconnects. Call when the auth token changes.</summary>

--- a/Views/Components/ChatPanel.axaml
+++ b/Views/Components/ChatPanel.axaml
@@ -43,8 +43,327 @@
             <ScrollViewer Grid.Row="1" x:Name="MessagesScroll"
                           HorizontalScrollBarVisibility="Disabled"
                           VerticalScrollBarVisibility="Auto">
+                <StackPanel>
+
+                <!-- Pinned message -->
+                <StackPanel IsVisible="{Binding PinnedMessage, Converter={x:Static ObjectConverters.IsNotNull}}">
+                <Border DataContext="{Binding PinnedMessage}"
+                        Padding="14,2" Margin="0,6,0,0">
+                    <Border.Styles>
+                        <Style Selector="Border.MessageRow">
+                            <Setter Property="Background" Value="Transparent"/>
+                        </Style>
+                        <Style Selector="Border.MessageRow:pointerover">
+                            <Setter Property="Background" Value="#0c1520"/>
+                        </Style>
+                        <Style Selector="Border.HoverToolbar">
+                            <Setter Property="Opacity" Value="0"/>
+                            <Setter Property="IsHitTestVisible" Value="False"/>
+                        </Style>
+                        <Style Selector="Border.MessageRow:pointerover Border.HoverToolbar">
+                            <Setter Property="Opacity" Value="1"/>
+                            <Setter Property="IsHitTestVisible" Value="True"/>
+                        </Style>
+                    </Border.Styles>
+                    <Panel>
+                    <Grid ColumnDefinitions="30,10,*">
+
+                        <!-- Avatar -->
+                        <Button Grid.Column="0"
+                                Width="30" Height="30"
+                                Padding="0"
+                                Background="Transparent"
+                                BorderThickness="0"
+                                VerticalAlignment="Top"
+                                Click="OnAuthorClicked">
+                            <Button.Styles>
+                                <Style Selector="Button:pointerover /template/ ContentPresenter">
+                                    <Setter Property="Background" Value="Transparent"/>
+                                    <Setter Property="Opacity" Value="0.8"/>
+                                </Style>
+                            </Button.Styles>
+                            <Grid Width="30" Height="30">
+                                <Border Width="30" Height="30" CornerRadius="15"
+                                        Background="#1e2a3a"
+                                        BorderBrush="#2d3842" BorderThickness="1">
+                                    <TextBlock Text="{Binding Initials}"
+                                               FontSize="{DynamicResource FontSizeXS}" Foreground="#3a90d6"
+                                               HorizontalAlignment="Center"
+                                               VerticalAlignment="Center"/>
+                                </Border>
+                                <Border Width="30" Height="30" CornerRadius="15"
+                                        ClipToBounds="True">
+                                    <Image Stretch="UniformToFill"
+                                           asyncImageLoader:ImageLoader.Source="{Binding AvatarUrl}"/>
+                                </Border>
+                                <Grid Width="10" Height="10"
+                                      IsVisible="{Binding IsOnline}"
+                                      HorizontalAlignment="Right" VerticalAlignment="Bottom"
+                                      Margin="0,0,-1,-1">
+                                    <Ellipse Width="10" Height="10" Fill="#1c2024"/>
+                                    <Ellipse Width="6" Height="6" Fill="#22ce22"
+                                             HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                                </Grid>
+                            </Grid>
+                        </Button>
+
+                        <!-- Body -->
+                        <StackPanel Grid.Column="2" Spacing="2">
+                            <!-- Name + role icons + time + pinned label -->
+                            <Grid ColumnDefinitions="Auto,Auto,*,Auto">
+                                <Button Grid.Column="0" Padding="0" Background="Transparent" BorderThickness="0"
+                                        HorizontalAlignment="Left"
+                                        Click="OnAuthorClicked">
+                                    <Button.Styles>
+                                        <Style Selector="Button:pointerover /template/ ContentPresenter">
+                                            <Setter Property="Background" Value="Transparent"/>
+                                        </Style>
+                                    </Button.Styles>
+                                    <TextBlock Text="{Binding AuthorName}"
+                                               FontSize="{DynamicResource FontSizeBase}" FontWeight="SemiBold"
+                                               Foreground="#d9dde0"
+                                               TextTrimming="CharacterEllipsis"/>
+                                </Button>
+                                <StackPanel Grid.Column="1" Orientation="Horizontal" Spacing="2"
+                                            VerticalAlignment="Center" Margin="4,0,0,0">
+                                    <materialIcons:MaterialIcon Kind="Shield"
+                                                                Width="14" Height="14"
+                                                                Foreground="#CD7F32"
+                                                                IsVisible="{Binding IsModerator}"
+                                                                ToolTip.Tip="{util:T 'chat.roleModeratorTooltip'}"/>
+                                    <materialIcons:MaterialIcon Kind="Shield"
+                                                                Width="14" Height="14"
+                                                                Foreground="#9E9E9E"
+                                                                IsVisible="{Binding IsAdmin}"
+                                                                ToolTip.Tip="{util:T 'chat.roleAdminTooltip'}"/>
+                                    <Button IsVisible="{Binding IsOld}"
+                                            Width="16" Height="16"
+                                            Padding="0"
+                                            Background="Transparent"
+                                            BorderThickness="0"
+                                            Cursor="Hand"
+                                            ToolTip.Tip="{Binding ChatIconTooltip}"
+                                            Click="OnDotaclassicPlusClicked">
+                                        <Button.Styles>
+                                            <Style Selector="Button:pointerover /template/ ContentPresenter">
+                                                <Setter Property="Background" Value="Transparent"/>
+                                                <Setter Property="Opacity" Value="0.8"/>
+                                            </Style>
+                                        </Button.Styles>
+                                        <Panel Width="16" Height="16">
+                                            <components:EmoticonImage
+                                                Bytes="{Binding ChatIconBytes}"
+                                                Width="16" Height="16"/>
+                                            <Image Source="avares://d2c-launcher/Assets/icon.ico"
+                                                   Width="14" Height="14"
+                                                   HorizontalAlignment="Center"
+                                                   VerticalAlignment="Center"
+                                                   IsVisible="{Binding ChatIconBytes, Converter={x:Static ObjectConverters.IsNull}}"/>
+                                        </Panel>
+                                    </Button>
+                                </StackPanel>
+                                <TextBlock Grid.Column="2"
+                                           Text="{Binding TimeText}"
+                                           FontSize="{DynamicResource FontSizeXS}" Foreground="#48525a"
+                                           VerticalAlignment="Bottom"
+                                           HorizontalAlignment="Left"
+                                           Margin="8,0,0,0"/>
+                                <TextBlock Grid.Column="3"
+                                           Text="{util:T 'chat.pinned'}"
+                                           FontSize="{DynamicResource FontSizeXS}" Foreground="#48525a"
+                                           VerticalAlignment="Bottom"
+                                           HorizontalAlignment="Right"
+                                           Margin="8,0,0,0"/>
+                            </Grid>
+                            <!-- Reply preview -->
+                            <Border IsVisible="{Binding HasReply}"
+                                    BorderBrush="#3a90d6" BorderThickness="2,0,0,0"
+                                    Background="#131820"
+                                    CornerRadius="0,3,3,0"
+                                    Padding="6,3"
+                                    Margin="0,0,0,2">
+                                <StackPanel Spacing="1">
+                                    <TextBlock Text="{Binding ReplyToAuthorName}"
+                                               FontSize="{DynamicResource FontSizeSM}" FontWeight="SemiBold"
+                                               Foreground="#3a90d6"
+                                               TextTrimming="CharacterEllipsis"/>
+                                    <TextBlock Text="{Binding ReplyToContent}"
+                                               FontSize="{DynamicResource FontSizeSM}" Foreground="#6b7a8d"
+                                               TextTrimming="CharacterEllipsis"
+                                               MaxLines="1"/>
+                                </StackPanel>
+                            </Border>
+                            <!-- Message text -->
+                            <components:RichMessageBlock
+                                Segments="{Binding RichContent}"/>
+                            <!-- Reactions -->
+                            <ItemsControl IsVisible="{Binding HasReactions}"
+                                          ItemsSource="{Binding Reactions}">
+                                <ItemsControl.ItemsPanel>
+                                    <ItemsPanelTemplate>
+                                        <WrapPanel Orientation="Horizontal"/>
+                                    </ItemsPanelTemplate>
+                                </ItemsControl.ItemsPanel>
+                                <ItemsControl.ItemTemplate>
+                                    <DataTemplate x:DataType="vm:ChatReactionViewModel">
+                                        <Button Command="{Binding ReactCommand}"
+                                                Classes.mine="{Binding IsMine}"
+                                                Margin="0,4,4,0" Padding="5,2"
+                                                CornerRadius="10"
+                                                BorderThickness="1"
+                                                Cursor="Hand">
+                                            <Button.Styles>
+                                                <Style Selector="Button">
+                                                    <Setter Property="Background" Value="#1a1f28"/>
+                                                    <Setter Property="BorderBrush" Value="#2d3842"/>
+                                                </Style>
+                                                <Style Selector="Button.mine">
+                                                    <Setter Property="Background" Value="#12233a"/>
+                                                    <Setter Property="BorderBrush" Value="#3a90d6"/>
+                                                </Style>
+                                                <Style Selector="Button:pointerover /template/ Border#PART_BorderElement">
+                                                    <Setter Property="Background" Value="#252c38"/>
+                                                    <Setter Property="BorderBrush" Value="#4a5a6e"/>
+                                                </Style>
+                                                <Style Selector="Button.mine:pointerover /template/ Border#PART_BorderElement">
+                                                    <Setter Property="Background" Value="#1a3050"/>
+                                                    <Setter Property="BorderBrush" Value="#5aaae8"/>
+                                                </Style>
+                                            </Button.Styles>
+                                            <StackPanel Orientation="Horizontal" Spacing="4"
+                                                        VerticalAlignment="Center">
+                                                <components:EmoticonImage
+                                                    Bytes="{Binding EmoticonBytes}"
+                                                    Width="20" Height="20"/>
+                                                <TextBlock Text="{Binding Count}"
+                                                           FontSize="{DynamicResource FontSizeXS}"
+                                                           Foreground="#a0b0c0"
+                                                           VerticalAlignment="Center"/>
+                                            </StackPanel>
+                                        </Button>
+                                    </DataTemplate>
+                                </ItemsControl.ItemTemplate>
+                            </ItemsControl>
+                        </StackPanel>
+
+                    </Grid>
+
+                    <!-- Hover toolbar -->
+                    <Canvas HorizontalAlignment="Stretch" VerticalAlignment="Top" Height="0">
+                    <Border Classes="HoverToolbar"
+                            Canvas.Right="4"
+                            Canvas.Top="-8"
+                            Background="#1a1f28"
+                            CornerRadius="8"
+                            BorderBrush="#2d3842"
+                            BorderThickness="1"
+                            Padding="4,2">
+                        <StackPanel Orientation="Horizontal" Spacing="2">
+
+                            <!-- Top-3 quick-react buttons -->
+                            <ItemsControl ItemsSource="{Binding QuickReacts}">
+                                <ItemsControl.ItemsPanel>
+                                    <ItemsPanelTemplate>
+                                        <StackPanel Orientation="Horizontal" Spacing="2"/>
+                                    </ItemsPanelTemplate>
+                                </ItemsControl.ItemsPanel>
+                                <ItemsControl.ItemTemplate>
+                                    <DataTemplate x:DataType="vm:ChatQuickReactViewModel">
+                                        <Button Classes="IconButton"
+                                                Command="{Binding ReactCommand}"
+                                                Background="Transparent"
+                                                BorderThickness="0"
+                                                Padding="4"
+                                                Width="28" Height="28"
+                                                Cursor="Hand"
+                                                CornerRadius="4"
+                                                ToolTip.Tip="{Binding Tooltip}">
+                                            <components:EmoticonImage Bytes="{Binding Bytes}"
+                                                          Width="20" Height="20"/>
+                                        </Button>
+                                    </DataTemplate>
+                                </ItemsControl.ItemTemplate>
+                            </ItemsControl>
+
+                            <!-- Reply button -->
+                            <Button Classes="IconButton"
+                                    Background="Transparent"
+                                    BorderThickness="0"
+                                    Padding="4"
+                                    Width="28" Height="28"
+                                    Cursor="Hand"
+                                    CornerRadius="4"
+                                    ToolTip.Tip="{util:T 'chat.reply'}"
+                                    Click="OnReplyClicked">
+                                <materialIcons:MaterialIcon Kind="ReplyOutline"
+                                                            Width="16" Height="16"
+                                                            Foreground="#48525a"/>
+                            </Button>
+
+                            <!-- "More emoticons" button with picker flyout -->
+                            <Button Classes="IconButton"
+                                    Background="Transparent"
+                                    BorderThickness="0"
+                                    Padding="4"
+                                    Width="28" Height="28"
+                                    Cursor="Hand"
+                                    CornerRadius="4"
+                                    ToolTip.Tip="{util:T 'chat.pickEmoticon'}">
+                                <Button.Flyout>
+                                    <Flyout Placement="TopEdgeAlignedRight">
+                                        <Border Background="#1a1f28"
+                                                CornerRadius="8"
+                                                BorderBrush="#2d3842"
+                                                BorderThickness="1"
+                                                Padding="6">
+                                            <ScrollViewer MaxHeight="300"
+                                                          VerticalScrollBarVisibility="Auto">
+                                            <ItemsControl ItemsSource="{Binding AllEmoticonReacts}"
+                                                          MaxWidth="256">
+                                                <ItemsControl.ItemsPanel>
+                                                    <ItemsPanelTemplate>
+                                                        <WrapPanel Orientation="Horizontal"/>
+                                                    </ItemsPanelTemplate>
+                                                </ItemsControl.ItemsPanel>
+                                                <ItemsControl.ItemTemplate>
+                                                    <DataTemplate x:DataType="vm:ChatQuickReactViewModel">
+                                                        <Button Classes="IconButton"
+                                                                Command="{Binding ReactCommand}"
+                                                                Click="OnPickerReactClicked"
+                                                                Background="Transparent"
+                                                                BorderThickness="0"
+                                                                Padding="4"
+                                                                Width="34" Height="34"
+                                                                Cursor="Hand"
+                                                                CornerRadius="4">
+                                                            <components:EmoticonImage Bytes="{Binding Bytes}"
+                                                                          Width="20" Height="20"/>
+                                                        </Button>
+                                                    </DataTemplate>
+                                                </ItemsControl.ItemTemplate>
+                                            </ItemsControl>
+                                            </ScrollViewer>
+                                        </Border>
+                                    </Flyout>
+                                </Button.Flyout>
+                                <materialIcons:MaterialIcon Kind="EmoticonOutline"
+                                                            Width="16" Height="16"
+                                                            Foreground="#48525a"/>
+                            </Button>
+
+                        </StackPanel>
+                    </Border>
+                    </Canvas>
+
+                    </Panel>
+                </Border>
+
+                <!-- Separator below pinned message -->
+                <Border Background="#1e2530" Height="1" Margin="0,2,0,0"/>
+                </StackPanel>
+
+                <!-- Loading placeholder -->
                 <Panel>
-                    <!-- Loading placeholder -->
                     <TextBlock Text="{x:Static res:Strings.Loading}"
                                IsVisible="{Binding IsLoading}"
                                Foreground="#48525a" FontSize="{DynamicResource FontSizeBase}"
@@ -376,6 +695,7 @@
                         </ItemsControl.ItemTemplate>
                     </ItemsControl>
                 </Panel>
+                </StackPanel>
             </ScrollViewer>
 
             <!-- Input -->

--- a/Views/Components/ChatPanel.axaml
+++ b/Views/Components/ChatPanel.axaml
@@ -13,7 +13,7 @@
 
 
     <Border Classes="Block">
-        <Grid RowDefinitions="36,*,Auto">
+        <Grid RowDefinitions="36,Auto,*,Auto">
 
             <!-- Header -->
             <Border Grid.Row="0" Classes="BlockHead">
@@ -39,15 +39,11 @@
                 </Grid>
             </Border>
 
-            <!-- Messages -->
-            <ScrollViewer Grid.Row="1" x:Name="MessagesScroll"
-                          HorizontalScrollBarVisibility="Disabled"
-                          VerticalScrollBarVisibility="Auto">
-                <StackPanel>
-
-                <!-- Pinned message -->
-                <StackPanel IsVisible="{Binding PinnedMessage, Converter={x:Static ObjectConverters.IsNotNull}}">
+            <!-- Pinned message (sticky, outside scroll) -->
+            <StackPanel Grid.Row="1"
+                        IsVisible="{Binding PinnedMessage, Converter={x:Static ObjectConverters.IsNotNull}}">
                 <Border DataContext="{Binding PinnedMessage}"
+                        Classes="MessageRow"
                         Padding="14,2" Margin="0,6,0,0">
                     <Border.Styles>
                         <Style Selector="Border.MessageRow">
@@ -196,54 +192,6 @@
                             <!-- Message text -->
                             <components:RichMessageBlock
                                 Segments="{Binding RichContent}"/>
-                            <!-- Reactions -->
-                            <ItemsControl IsVisible="{Binding HasReactions}"
-                                          ItemsSource="{Binding Reactions}">
-                                <ItemsControl.ItemsPanel>
-                                    <ItemsPanelTemplate>
-                                        <WrapPanel Orientation="Horizontal"/>
-                                    </ItemsPanelTemplate>
-                                </ItemsControl.ItemsPanel>
-                                <ItemsControl.ItemTemplate>
-                                    <DataTemplate x:DataType="vm:ChatReactionViewModel">
-                                        <Button Command="{Binding ReactCommand}"
-                                                Classes.mine="{Binding IsMine}"
-                                                Margin="0,4,4,0" Padding="5,2"
-                                                CornerRadius="10"
-                                                BorderThickness="1"
-                                                Cursor="Hand">
-                                            <Button.Styles>
-                                                <Style Selector="Button">
-                                                    <Setter Property="Background" Value="#1a1f28"/>
-                                                    <Setter Property="BorderBrush" Value="#2d3842"/>
-                                                </Style>
-                                                <Style Selector="Button.mine">
-                                                    <Setter Property="Background" Value="#12233a"/>
-                                                    <Setter Property="BorderBrush" Value="#3a90d6"/>
-                                                </Style>
-                                                <Style Selector="Button:pointerover /template/ Border#PART_BorderElement">
-                                                    <Setter Property="Background" Value="#252c38"/>
-                                                    <Setter Property="BorderBrush" Value="#4a5a6e"/>
-                                                </Style>
-                                                <Style Selector="Button.mine:pointerover /template/ Border#PART_BorderElement">
-                                                    <Setter Property="Background" Value="#1a3050"/>
-                                                    <Setter Property="BorderBrush" Value="#5aaae8"/>
-                                                </Style>
-                                            </Button.Styles>
-                                            <StackPanel Orientation="Horizontal" Spacing="4"
-                                                        VerticalAlignment="Center">
-                                                <components:EmoticonImage
-                                                    Bytes="{Binding EmoticonBytes}"
-                                                    Width="20" Height="20"/>
-                                                <TextBlock Text="{Binding Count}"
-                                                           FontSize="{DynamicResource FontSizeXS}"
-                                                           Foreground="#a0b0c0"
-                                                           VerticalAlignment="Center"/>
-                                            </StackPanel>
-                                        </Button>
-                                    </DataTemplate>
-                                </ItemsControl.ItemTemplate>
-                            </ItemsControl>
                         </StackPanel>
 
                     </Grid>
@@ -360,7 +308,13 @@
 
                 <!-- Separator below pinned message -->
                 <Border Background="#1e2530" Height="1" Margin="0,2,0,0"/>
-                </StackPanel>
+            </StackPanel>
+
+            <!-- Messages -->
+            <ScrollViewer Grid.Row="2" x:Name="MessagesScroll"
+                          HorizontalScrollBarVisibility="Disabled"
+                          VerticalScrollBarVisibility="Auto">
+                <StackPanel>
 
                 <!-- Loading placeholder -->
                 <Panel>
@@ -699,7 +653,7 @@
             </ScrollViewer>
 
             <!-- Input -->
-            <Border Grid.Row="2"
+            <Border Grid.Row="3"
                     BorderBrush="#1e2530" BorderThickness="0,1,0,0">
                 <StackPanel>
                 <!-- Reply preview banner -->

--- a/memory-bank/activeContext.md
+++ b/memory-bank/activeContext.md
@@ -12,6 +12,7 @@ Repository AI workflow files use a shared `.agents/` layout. `.agents/commands/`
 
 | Issue | What was done |
 |-------|--------------|
+| #181 | Pinned message in chat — fetched from thread info API, displayed as first chat item with "Закреплено" badge |
 | #168 | Chat subscriber icon: replaced star fallback with d2c logo (`icon.ico`) |
 | #177 | Subscription tab in profile — dodge list + Plus subscription status, owner-only |
 | #176 | Notification sound volume setting |


### PR DESCRIPTION
## Summary

- Fetches pinned message from `GET /v1/forum/thread/{id}/forum` on chat start and window focus
- Displays it as the first item in the chat, visually identical to a regular message, with a "Закреплено" label aligned to the right of the header row
- A thin separator line divides it from regular messages
- On hover, the full toolbar (quick-react, reply, emoticon picker) is active
- Extracts `MapThreadMessage()` helper in `BackendApiService` to deduplicate `ThreadMessageDTO → ChatMessageData` mapping
- Added preview stub returning a realistic pinned message

## Test plan

- [ ] Open chat — pinned message appears at the top with "Закреплено" badge
- [ ] No pinned message → section is hidden, no separator shown
- [ ] Hover over pinned message → toolbar appears (quick-react, reply, emoticon picker)
- [ ] Reply to pinned message works
- [ ] Emoticons in pinned message re-parsed when snapshot loads
- [ ] Preview tool: `tools/preview.ps1 ChatPanel` shows pinned message above regular messages

Closes #181

🤖 Generated with [Claude Code](https://claude.com/claude-code)