### PR TITLE
feat: latest news panel in Play tab side column

### DIFF
--- a/Preview/PreviewRegistry.cs
+++ b/Preview/PreviewRegistry.cs
@@ -778,6 +778,11 @@ public static class PreviewRegistry
                 var vm = new StreamsViewModel(api);
                 return (new StreamsPanel { Width = 900, Height = 700, DataContext = vm }, null);
             },
+            ["LatestNewsPanel"] = () =>
+            {
+                var vm = new LatestNewsViewModel(new StubBackendApiService());
+                return (new LatestNewsPanel { Width = 220, DataContext = vm }, null);
+            },
             ["InviteModal"] = () =>
             {
                 var stub = new StubQueueSocketService();

--- a/Preview/PreviewStubs.cs
+++ b/Preview/PreviewStubs.cs
@@ -214,6 +214,21 @@ internal sealed class StubBackendApiService : IBackendApiService
 
     public Task StartRecalibrationAsync(CancellationToken cancellationToken = default)
         => Task.CompletedTask;
+
+    public Task<d2c_launcher.Api.BlogpostDto?> GetLatestBlogPostAsync(CancellationToken cancellationToken = default)
+        => Task.FromResult<d2c_launcher.Api.BlogpostDto?>(new d2c_launcher.Api.BlogpostDto
+        {
+            Id = 1,
+            Title = "Dotaclassic 6.82: обновление баланса и новые герои",
+            ShortDescription = "В этом обновлении мы скорректировали баланс нескольких героев и добавили новые предметы.",
+            Image = new d2c_launcher.Api.UploadedImageDto { Url = "https://placehold.co/400x200/0d1520/4a90d6?text=News", Key = "preview" },
+            PublishDate = "28 апреля 2026",
+            CreatedAt = "2026-04-28",
+            Content = "",
+            RenderedContentHtml = "",
+            Published = true,
+            Author = new d2c_launcher.Api.UserDTO { SteamId = "0", Name = "Admin", Avatar = "", AvatarSmall = "" },
+        });
 }
 
 internal sealed class StubPaidActionService : IPaidActionService

--- a/Resources/Locales/ru.json
+++ b/Resources/Locales/ru.json
@@ -260,6 +260,9 @@
     "recalibrationConfirm": "Начать",
     "recalibrationCancel": "Отмена"
   },
+  "news": {
+    "title": "НОВОСТИ"
+  },
   "streams": {
     "tabLabel": "СТРИМЫ",
     "viewers": "зрителей",

--- a/Services/BackendApiService.cs
+++ b/Services/BackendApiService.cs
@@ -489,6 +489,21 @@ public sealed class BackendApiService : IBackendApiService, IDisposable
         }
     }
 
+    public async Task<Api.BlogpostDto?> GetLatestBlogPostAsync(CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            var api = new DotaclassicApiClient(_httpClient);
+            var page = await api.BlogpostController_blogPageAsync(1, per_page: 1, cancellationToken).ConfigureAwait(false);
+            return page?.Data?.FirstOrDefault();
+        }
+        catch (Exception ex)
+        {
+            AppLog.Error("GetLatestBlogPostAsync failed", ex);
+            return null;
+        }
+    }
+
     public async IAsyncEnumerable<Api.LiveMatchDto> SubscribeLiveMatchAsync(
         int matchId,
         [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken cancellationToken = default)

--- a/Services/IBackendApiService.cs
+++ b/Services/IBackendApiService.cs
@@ -51,4 +51,6 @@ public interface IBackendApiService
     Task DodgePlayerAsync(string steamId, CancellationToken cancellationToken = default);
     /// <summary>Starts MMR recalibration for the authenticated user. Only allowed once per season.</summary>
     Task StartRecalibrationAsync(CancellationToken cancellationToken = default);
+    /// <summary>Returns the latest published blog post, or null if none exist or the request fails.</summary>
+    Task<d2c_launcher.Api.BlogpostDto?> GetLatestBlogPostAsync(CancellationToken cancellationToken = default);
 }

--- a/ViewModels/LatestNewsViewModel.cs
+++ b/ViewModels/LatestNewsViewModel.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Diagnostics;
+using System.Globalization;
 using System.Threading.Tasks;
 using Avalonia.Threading;
 using CommunityToolkit.Mvvm.ComponentModel;
@@ -13,14 +14,27 @@ namespace d2c_launcher.ViewModels;
 public partial class LatestNewsViewModel : ObservableObject
 {
     private const string BlogBaseUrl = "https://dotaclassic.ru/blog/";
+    private static readonly CultureInfo RuCulture = new("ru-RU");
 
     [ObservableProperty]
     [NotifyPropertyChangedFor(nameof(HasPost))]
     [NotifyPropertyChangedFor(nameof(PostUrl))]
+    [NotifyPropertyChangedFor(nameof(FormattedPublishDate))]
     private BlogpostDto? _post;
 
     public bool HasPost => Post != null;
     public string? PostUrl => Post != null ? BlogBaseUrl + (int)Post.Id : null;
+    public string? FormattedPublishDate => FormatDate(Post?.PublishDate);
+
+    private static string? FormatDate(string? raw)
+    {
+        if (string.IsNullOrWhiteSpace(raw)) return null;
+        if (DateTimeOffset.TryParse(raw, null, DateTimeStyles.RoundtripKind, out var dto))
+            return dto.ToString("d MMMM yyyy", RuCulture);
+        if (DateTime.TryParse(raw, out var dt))
+            return dt.ToString("d MMMM yyyy", RuCulture);
+        return raw;
+    }
 
     public LatestNewsViewModel(IBackendApiService backendApiService)
     {

--- a/ViewModels/LatestNewsViewModel.cs
+++ b/ViewModels/LatestNewsViewModel.cs
@@ -1,0 +1,43 @@
+using System;
+using System.Diagnostics;
+using System.Threading.Tasks;
+using Avalonia.Threading;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using d2c_launcher.Api;
+using d2c_launcher.Services;
+using d2c_launcher.Util;
+
+namespace d2c_launcher.ViewModels;
+
+public partial class LatestNewsViewModel : ObservableObject
+{
+    private const string BlogBaseUrl = "https://dotaclassic.ru/blog/";
+
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(HasPost))]
+    [NotifyPropertyChangedFor(nameof(PostUrl))]
+    private BlogpostDto? _post;
+
+    public bool HasPost => Post != null;
+    public string? PostUrl => Post != null ? BlogBaseUrl + (int)Post.Id : null;
+
+    public LatestNewsViewModel(IBackendApiService backendApiService)
+    {
+        LoadAsync(backendApiService).FireAndForget("LatestNewsViewModel.LoadAsync");
+    }
+
+    private async Task LoadAsync(IBackendApiService backendApiService)
+    {
+        var post = await backendApiService.GetLatestBlogPostAsync().ConfigureAwait(false);
+        Dispatcher.UIThread.Post(() => Post = post);
+    }
+
+    [RelayCommand]
+    private void OpenPost()
+    {
+        if (PostUrl is not { } url) return;
+        if (!Uri.TryCreate(url, UriKind.Absolute, out var uri)) return;
+        Process.Start(new ProcessStartInfo(uri.AbsoluteUri) { UseShellExecute = true });
+    }
+}

--- a/ViewModels/MainLauncherViewModel.cs
+++ b/ViewModels/MainLauncherViewModel.cs
@@ -56,6 +56,7 @@ public partial class MainLauncherViewModel : ViewModelBase, IDisposable
     public ProfileViewModel Profile { get; }
     public LiveViewModel Live { get; }
     public StreamsViewModel Streams { get; }
+    public LatestNewsViewModel News { get; }
 
     // ── Auth / user state ─────────────────────────────────────────────────────
     [ObservableProperty]
@@ -194,6 +195,7 @@ public partial class MainLauncherViewModel : ViewModelBase, IDisposable
         Streams = new StreamsViewModel(backendApiService);
         Streams.PlayerSettingsUrl = BuildStreamsSettingsUrl(_currentUser);
         Streams.PropertyChanged += OnStreamsPropertyChanged;
+        News = new LatestNewsViewModel(backendApiService);
 
         _soundCoordinator = new SocketEventCoordinator(queueSocketService, NotificationArea, windowService, backendApiService,
             toastNotificationService,

--- a/Views/Components/LatestNewsPanel.axaml
+++ b/Views/Components/LatestNewsPanel.axaml
@@ -54,7 +54,7 @@
                        MaxLines="2"
                        TextWrapping="Wrap"
                        LineHeight="18"/>
-            <TextBlock Text="{Binding Post.PublishDate}"
+            <TextBlock Text="{Binding FormattedPublishDate}"
                        Foreground="#556070"
                        FontSize="{DynamicResource FontSizeXS}"/>
           </StackPanel>

--- a/Views/Components/LatestNewsPanel.axaml
+++ b/Views/Components/LatestNewsPanel.axaml
@@ -1,0 +1,70 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:vm="using:d2c_launcher.ViewModels"
+             xmlns:asyncImageLoader="clr-namespace:AsyncImageLoader;assembly=AsyncImageLoader.Avalonia"
+             xmlns:l="clr-namespace:d2c_launcher.Util"
+             x:Class="d2c_launcher.Views.Components.LatestNewsPanel"
+             x:DataType="vm:LatestNewsViewModel">
+
+  <Border Classes="Block" ClipToBounds="True"
+          IsVisible="{Binding HasPost}">
+    <Grid RowDefinitions="Auto,Auto">
+
+      <!-- Header -->
+      <Border Grid.Row="0" Classes="BlockHead">
+        <TextBlock Classes="BlockTitle" Text="{l:T 'news.title'}"/>
+      </Border>
+
+      <!-- Card -->
+      <Button Grid.Row="1"
+              Command="{Binding OpenPostCommand}"
+              Background="Transparent" BorderThickness="0"
+              Padding="0" HorizontalContentAlignment="Stretch"
+              Cursor="Hand" CornerRadius="0">
+        <Button.Styles>
+          <Style Selector="Button /template/ ContentPresenter">
+            <Setter Property="Background" Value="Transparent"/>
+          </Style>
+          <Style Selector="Button:pointerover /template/ ContentPresenter">
+            <Setter Property="Background" Value="#0d1118"/>
+          </Style>
+        </Button.Styles>
+
+        <ToolTip.Tip>
+          <TextBlock Text="{Binding Post.ShortDescription}"
+                     MaxWidth="200"
+                     TextWrapping="Wrap"
+                     IsVisible="{Binding Post.ShortDescription,
+                       Converter={x:Static StringConverters.IsNotNullOrEmpty}}"/>
+        </ToolTip.Tip>
+
+        <Grid RowDefinitions="Auto,Auto">
+
+          <!-- Thumbnail -->
+          <Border Grid.Row="0" Height="110" ClipToBounds="True" Background="#0a0f18">
+            <Image asyncImageLoader:ImageLoader.Source="{Binding Post.Image.Url}"
+                   Stretch="UniformToFill"/>
+          </Border>
+
+          <!-- Info -->
+          <StackPanel Grid.Row="1" Margin="12,10,12,12" Spacing="4">
+            <TextBlock Text="{Binding Post.Title}"
+                       Foreground="#d0d8e0"
+                       FontSize="{DynamicResource FontSizeSM}"
+                       FontWeight="SemiBold"
+                       TextTrimming="CharacterEllipsis"
+                       MaxLines="2"
+                       TextWrapping="Wrap"
+                       LineHeight="18"/>
+            <TextBlock Text="{Binding Post.PublishDate}"
+                       Foreground="#556070"
+                       FontSize="{DynamicResource FontSizeXS}"/>
+          </StackPanel>
+
+        </Grid>
+      </Button>
+
+    </Grid>
+  </Border>
+
+</UserControl>

--- a/Views/Components/LatestNewsPanel.axaml
+++ b/Views/Components/LatestNewsPanel.axaml
@@ -33,9 +33,7 @@
         <ToolTip.Tip>
           <TextBlock Text="{Binding Post.ShortDescription}"
                      MaxWidth="200"
-                     TextWrapping="Wrap"
-                     IsVisible="{Binding Post.ShortDescription,
-                       Converter={x:Static StringConverters.IsNotNullOrEmpty}}"/>
+                     TextWrapping="Wrap"/>
         </ToolTip.Tip>
 
         <Grid RowDefinitions="Auto,Auto">

--- a/Views/Components/LatestNewsPanel.axaml.cs
+++ b/Views/Components/LatestNewsPanel.axaml.cs
@@ -1,0 +1,11 @@
+using Avalonia.Controls;
+
+namespace d2c_launcher.Views.Components;
+
+public partial class LatestNewsPanel : UserControl
+{
+    public LatestNewsPanel()
+    {
+        InitializeComponent();
+    }
+}

--- a/Views/Components/LauncherHeader.axaml
+++ b/Views/Components/LauncherHeader.axaml
@@ -83,7 +83,7 @@
     </Style>
   </UserControl.Styles>
 
-  <Border BorderBrush="#1e2530" BorderThickness="0">
+  <Border Background="#080a0d" BorderBrush="#252E3A" BorderThickness="0,0,0,1">
     <Grid ColumnDefinitions="Auto,*,Auto" Margin="12,0,12,0">
 
       <!-- Left: navigation tabs -->

--- a/Views/MainLauncherView.axaml
+++ b/Views/MainLauncherView.axaml
@@ -21,11 +21,15 @@
                <components:LauncherHeader x:Name="LauncherHeaderControl" Grid.Row="0" DataContext="{Binding}"/>
 
                <!-- PLAY tab content -->
-               <Grid Grid.Row="1" Margin="20,8,20,10" ColumnDefinitions="*,360"
+               <Grid Grid.Row="1" Margin="20,8,20,10" ColumnDefinitions="220,*,360"
                      IsVisible="{Binding IsPlayTabActive}">
-                   <components:ChatPanel Grid.Column="0" Margin="0,0,16,0"
+                   <!-- Side panels column (news + future panels) -->
+                   <StackPanel Grid.Column="0" Margin="0,0,16,0" Spacing="12">
+                       <components:LatestNewsPanel DataContext="{Binding News}"/>
+                   </StackPanel>
+                   <components:ChatPanel Grid.Column="1" Margin="0,0,16,0"
                                          DataContext="{Binding Chat}"/>
-                   <Grid Grid.Column="1" RowDefinitions="Auto,*,Auto">
+                   <Grid Grid.Column="2" RowDefinitions="Auto,*,Auto">
                        <components:PartyPanel Grid.Row="0"
                                               DataContext="{Binding Party}"
                                               InviteClicked="OnInvitePlayerClicked"/>


### PR DESCRIPTION
## Summary

- Adds a 220px side column to the left of the chat in the Play tab
- `LatestNewsPanel` fetches the most recent blog post on load and shows image, title, and publish date
- Hovering shows the short description as a tooltip
- Clicking the card opens `https://dotaclassic.ru/blog/{id}` in the browser
- Column is a `StackPanel` — future panels can stack below the news card

## Test plan

- [ ] Launch app and verify the news card appears in the new left column on the Play tab
- [ ] Confirm clicking the card opens the correct URL in the default browser
- [ ] Confirm hovering shows the short description tooltip
- [ ] Confirm layout is correct: `[news column] [chat] [party/queue]`
- [ ] Confirm no visual regression on other tabs (Live, Streams, Profile)

Closes #171

🤖 Generated with [Claude Code](https://claude.com/claude-code)