### PR TITLE
chore: set BitmapInterpolationMode=HighQuality on all Image elements

### DIFF
--- a/Views/Components/AcceptGameModal.axaml
+++ b/Views/Components/AcceptGameModal.axaml
@@ -41,7 +41,7 @@
                                    <TextBlock Text="{Binding Initials}"
                                               HorizontalAlignment="Center" VerticalAlignment="Center"
                                               FontSize="{DynamicResource FontSizeMD}" FontWeight="SemiBold" Foreground="#D9D9D9"/>
-                                   <Image Stretch="UniformToFill"
+                                   <Image RenderOptions.BitmapInterpolationMode="HighQuality" Stretch="UniformToFill"
                                           asyncImageLoader:ImageLoader.Source="{Binding AvatarUrl}"/>
                                </Panel>
                            </Border>

--- a/Views/Components/AdBannerPanel.axaml
+++ b/Views/Components/AdBannerPanel.axaml
@@ -30,7 +30,7 @@
 
           <!-- Image -->
           <Border Grid.Row="0" Height="90" ClipToBounds="True" Background="#0a0f18">
-            <Image Source="avares://d2c-launcher/Assets/Images/collectors.jpg"
+            <Image RenderOptions.BitmapInterpolationMode="HighQuality" Source="avares://d2c-launcher/Assets/Images/collectors.jpg"
                    Stretch="UniformToFill"/>
           </Border>
 

--- a/Views/Components/ChatPanel.axaml
+++ b/Views/Components/ChatPanel.axaml
@@ -23,12 +23,12 @@
                         <Button Background="Transparent" BorderThickness="0" Padding="4"
                                 Cursor="Hand" Click="OnTelegramClicked"
                                 ToolTip.Tip="Telegram">
-                            <Image Source="avares://d2c-launcher/Assets/Images/telegram.png" Width="18" Height="18"/>
+                            <Image RenderOptions.BitmapInterpolationMode="HighQuality" Source="avares://d2c-launcher/Assets/Images/telegram.png" Width="18" Height="18"/>
                         </Button>
                         <Button Background="Transparent" BorderThickness="0" Padding="4"
                                 Cursor="Hand" Click="OnDiscordClicked"
                                 ToolTip.Tip="Discord">
-                            <Image Source="avares://d2c-launcher/Assets/Images/discord.png" Width="18" Height="18"/>
+                            <Image RenderOptions.BitmapInterpolationMode="HighQuality" Source="avares://d2c-launcher/Assets/Images/discord.png" Width="18" Height="18"/>
                         </Button>
                         <Button Background="Transparent" BorderThickness="0" Padding="4"
                                 Cursor="Hand" Click="OnSiteClicked"
@@ -89,7 +89,7 @@
                                 </Border>
                                 <Border Width="30" Height="30" CornerRadius="15"
                                         ClipToBounds="True">
-                                    <Image Stretch="UniformToFill"
+                                    <Image RenderOptions.BitmapInterpolationMode="HighQuality" Stretch="UniformToFill"
                                            asyncImageLoader:ImageLoader.Source="{Binding AvatarUrl}"/>
                                 </Border>
                                 <Grid Width="10" Height="10"
@@ -150,7 +150,7 @@
                                             <components:EmoticonImage
                                                 Bytes="{Binding ChatIconBytes}"
                                                 Width="16" Height="16"/>
-                                            <Image Source="avares://d2c-launcher/Assets/icon.ico"
+                                            <Image RenderOptions.BitmapInterpolationMode="HighQuality" Source="avares://d2c-launcher/Assets/icon.ico"
                                                    Width="14" Height="14"
                                                    HorizontalAlignment="Center"
                                                    VerticalAlignment="Center"
@@ -380,7 +380,7 @@
                                                 <!-- Actual avatar (overlays initials while loading) -->
                                                 <Border Width="30" Height="30" CornerRadius="15"
                                                         ClipToBounds="True">
-                                                    <Image Stretch="UniformToFill"
+                                                    <Image RenderOptions.BitmapInterpolationMode="HighQuality" Stretch="UniformToFill"
                                                            asyncImageLoader:ImageLoader.Source="{Binding AvatarUrl}"/>
                                                 </Border>
                                                 <!-- Online indicator dot (20% of 30px avatar, 2px outline) -->
@@ -447,7 +447,7 @@
                                                             <components:EmoticonImage
                                                                 Bytes="{Binding ChatIconBytes}"
                                                                 Width="16" Height="16"/>
-                                                            <Image Source="avares://d2c-launcher/Assets/icon.ico"
+                                                            <Image RenderOptions.BitmapInterpolationMode="HighQuality" Source="avares://d2c-launcher/Assets/icon.ico"
                                                                    Width="14" Height="14"
                                                                    HorizontalAlignment="Center"
                                                                    VerticalAlignment="Center"

--- a/Views/Components/LatestNewsPanel.axaml
+++ b/Views/Components/LatestNewsPanel.axaml
@@ -40,7 +40,7 @@
 
           <!-- Thumbnail -->
           <Border Grid.Row="0" Height="110" ClipToBounds="True" Background="#0a0f18">
-            <Image asyncImageLoader:ImageLoader.Source="{Binding Post.Image.Url}"
+            <Image RenderOptions.BitmapInterpolationMode="HighQuality" asyncImageLoader:ImageLoader.Source="{Binding Post.Image.Url}"
                    Stretch="UniformToFill"/>
           </Border>
 

--- a/Views/Components/LauncherHeader.axaml
+++ b/Views/Components/LauncherHeader.axaml
@@ -236,7 +236,7 @@
                 Background="Transparent" BorderThickness="0" CornerRadius="0"
                 Cursor="Hand" Click="OnD2CPlusClicked"
                 ToolTip.Tip="Dotaclassic Plus">
-          <Image Source="avares://d2c-launcher/Assets/icon.ico" Width="20" Height="20"/>
+          <Image RenderOptions.BitmapInterpolationMode="HighQuality" Source="avares://d2c-launcher/Assets/icon.ico" Width="20" Height="20"/>
         </Button>
         <Button x:Name="ProfileButton" VerticalAlignment="Stretch" Padding="10,8"
                 Background="Transparent" BorderThickness="0" CornerRadius="0"
@@ -245,7 +245,7 @@
             <Grid Width="32" Height="32">
               <Border Width="32" Height="32" CornerRadius="0" ClipToBounds="True"
                       Background="#2d3842">
-                <Image Source="{Binding AvatarImage}" Width="32" Height="32" Stretch="UniformToFill"/>
+                <Image RenderOptions.BitmapInterpolationMode="HighQuality" Source="{Binding AvatarImage}" Width="32" Height="32" Stretch="UniformToFill"/>
               </Border>
               <Ellipse Width="9" Height="9" Fill="#4CAF50"
                        HorizontalAlignment="Right" VerticalAlignment="Bottom"

--- a/Views/Components/NotificationArea.axaml
+++ b/Views/Components/NotificationArea.axaml
@@ -23,7 +23,7 @@
                                        Width="42" Height="42"
                                        ClipToBounds="True"
                                        Background="#242c34">
-                                   <Image Stretch="UniformToFill"
+                                   <Image RenderOptions.BitmapInterpolationMode="HighQuality" Stretch="UniformToFill"
                                           asyncImageLoader:ImageLoader.Source="{Binding InviterAvatarUrl}"/>
                                </Border>
                                <StackPanel Grid.Column="1" Margin="10,0,0,0" VerticalAlignment="Center">
@@ -81,7 +81,7 @@
                                    Width="36" Height="36"
                                    ClipToBounds="True"
                                    Background="#242c34">
-                               <Image Stretch="UniformToFill"
+                               <Image RenderOptions.BitmapInterpolationMode="HighQuality" Stretch="UniformToFill"
                                       asyncImageLoader:ImageLoader.Source="{Binding AvatarUrl}"/>
                            </Border>
                            <!-- Name + label -->
@@ -181,7 +181,7 @@
                            <!-- Header: icon + title + dismiss -->
                            <Grid ColumnDefinitions="Auto,*,Auto">
                                <!-- Achievement image -->
-                               <Image Grid.Column="0"
+                               <Image RenderOptions.BitmapInterpolationMode="HighQuality" Grid.Column="0"
                                       Width="48" Height="48"
                                       IsVisible="{Binding ImageUrl, Converter={x:Static ObjectConverters.IsNotNull}}"
                                       asyncImageLoader:ImageLoader.Source="{Binding ImageUrl}"/>

--- a/Views/Components/PartyPanel.axaml
+++ b/Views/Components/PartyPanel.axaml
@@ -70,7 +70,7 @@
                                                   HorizontalAlignment="Center" VerticalAlignment="Center"
                                                   FontSize="{DynamicResource FontSizeLG}" FontWeight="SemiBold" Foreground="#AAAAAA"/>
                                        <!-- Avatar overlay via AsyncImageLoader -->
-                                       <Image Stretch="UniformToFill"
+                                       <Image RenderOptions.BitmapInterpolationMode="HighQuality" Stretch="UniformToFill"
                                               asyncImageLoader:ImageLoader.Source="{Binding AvatarUrl}"/>
                                    </Panel>
                                </Border>

--- a/Views/Components/ProfilePanel.axaml
+++ b/Views/Components/ProfilePanel.axaml
@@ -56,7 +56,7 @@
               <Border Grid.Column="0" Width="60" Height="60" Margin="0,14,16,14"
                       BorderBrush="#252E3A" BorderThickness="1" VerticalAlignment="Center">
                 <Panel>
-                  <Image asyncImageLoader:ImageLoader.Source="{Binding AvatarUrl}" Stretch="UniformToFill"
+                  <Image RenderOptions.BitmapInterpolationMode="HighQuality" asyncImageLoader:ImageLoader.Source="{Binding AvatarUrl}" Stretch="UniformToFill"
                          IsVisible="{Binding AvatarUrl, Converter={x:Static StringConverters.IsNotNullOrEmpty}}"/>
                   <Border Background="#1A2535"
                           IsVisible="{Binding AvatarUrl, Converter={x:Static StringConverters.IsNullOrEmpty}}">
@@ -331,7 +331,7 @@
                           <Border Width="34" Height="24" ClipToBounds="True"
                                   BorderBrush="#252E3A" BorderThickness="1"
                                   Background="#1A2030">
-                            <Image asyncImageLoader:ImageLoader.Source="{Binding HeroImageUrl}"
+                            <Image RenderOptions.BitmapInterpolationMode="HighQuality" asyncImageLoader:ImageLoader.Source="{Binding HeroImageUrl}"
                                    Stretch="UniformToFill"/>
                           </Border>
                           <TextBlock Text="{Binding HeroName}"
@@ -462,7 +462,7 @@
                           <Border Grid.Column="0" Width="32" Height="32" Margin="0,0,12,0"
                                   ClipToBounds="True" BorderBrush="#252E3A" BorderThickness="1"
                                   Background="#1A2030">
-                            <Image asyncImageLoader:ImageLoader.Source="{Binding AvatarUrl}"
+                            <Image RenderOptions.BitmapInterpolationMode="HighQuality" asyncImageLoader:ImageLoader.Source="{Binding AvatarUrl}"
                                    Stretch="UniformToFill"
                                    IsVisible="{Binding AvatarUrl, Converter={x:Static StringConverters.IsNotNullOrEmpty}}"/>
                           </Border>

--- a/Views/Components/RewardModal.axaml
+++ b/Views/Components/RewardModal.axaml
@@ -18,14 +18,14 @@
 
                 <!-- Image: local (subscription splash) -->
                 <Panel IsVisible="{Binding HasLocalImage}">
-                    <Image Source="{Binding LocalImage}"
+                    <Image RenderOptions.BitmapInterpolationMode="HighQuality" Source="{Binding LocalImage}"
                            Stretch="Uniform" HorizontalAlignment="Center" VerticalAlignment="Center"
                            MaxHeight="200" Margin="0,16,0,0"/>
                 </Panel>
 
                 <!-- Image: remote (item drops) -->
                 <Panel IsVisible="{Binding HasRemoteImage}" Height="220" ClipToBounds="True">
-                    <Image asyncImageLoader:ImageLoader.Source="{Binding RemoteImageUrl}"
+                    <Image RenderOptions.BitmapInterpolationMode="HighQuality" asyncImageLoader:ImageLoader.Source="{Binding RemoteImageUrl}"
                            Stretch="UniformToFill" HorizontalAlignment="Center" VerticalAlignment="Center"/>
                     <Border VerticalAlignment="Bottom" Height="80">
                         <Border.Background>

--- a/Views/Components/StorePanel.axaml
+++ b/Views/Components/StorePanel.axaml
@@ -10,7 +10,7 @@
 
       <!-- ═══ HERO ═══ -->
       <Panel MinHeight="300" ClipToBounds="True">
-        <Image Source="avares://d2c-launcher/Assets/Images/splash/subscription.webp"
+        <Image RenderOptions.BitmapInterpolationMode="HighQuality" Source="avares://d2c-launcher/Assets/Images/splash/subscription.webp"
                Stretch="UniformToFill" HorizontalAlignment="Center" VerticalAlignment="Center"/>
 
         <!-- Uniform dim -->
@@ -54,7 +54,7 @@
                   Padding="22,10" CornerRadius="2" Cursor="Hand"
                   HorizontalAlignment="Center">
             <StackPanel Orientation="Horizontal" Spacing="10">
-              <Image Source="avares://d2c-launcher/Assets/Images/telegram.png"
+              <Image RenderOptions.BitmapInterpolationMode="HighQuality" Source="avares://d2c-launcher/Assets/Images/telegram.png"
                      Width="15" Height="15" VerticalAlignment="Center"/>
               <TextBlock Text="{Binding StoreButtonText}"
                          FontSize="{DynamicResource FontSizeMD}" FontWeight="Bold"/>
@@ -85,7 +85,7 @@
 
       <!-- FEATURE 1 — decorations -->
       <Panel MinHeight="330" ClipToBounds="True">
-        <Image Source="avares://d2c-launcher/Assets/Images/splash/decoration.webp"
+        <Image RenderOptions.BitmapInterpolationMode="HighQuality" Source="avares://d2c-launcher/Assets/Images/splash/decoration.webp"
                Stretch="UniformToFill" HorizontalAlignment="Center" VerticalAlignment="Center"/>
         <Border Background="#48000000"/>
         <!-- Bottom caption gradient -->
@@ -113,7 +113,7 @@
 
       <!-- FEATURE 2 — dodge -->
       <Panel MinHeight="330" ClipToBounds="True">
-        <Image Source="avares://d2c-launcher/Assets/Images/splash/dodge.webp"
+        <Image RenderOptions.BitmapInterpolationMode="HighQuality" Source="avares://d2c-launcher/Assets/Images/splash/dodge.webp"
                Stretch="UniformToFill" HorizontalAlignment="Center" VerticalAlignment="Center"/>
         <Border Background="#48000000"/>
         <!-- Bottom caption gradient -->
@@ -141,7 +141,7 @@
 
       <!-- FEATURE 3 — unban -->
       <Panel MinHeight="330" ClipToBounds="True">
-        <Image Source="avares://d2c-launcher/Assets/Images/splash/unban.webp"
+        <Image RenderOptions.BitmapInterpolationMode="HighQuality" Source="avares://d2c-launcher/Assets/Images/splash/unban.webp"
                Stretch="UniformToFill" HorizontalAlignment="Center" VerticalAlignment="Center"/>
         <Border Background="#48000000"/>
         <!-- Bottom caption gradient -->
@@ -169,7 +169,7 @@
 
       <!-- FEATURE 4 — praise -->
       <Panel MinHeight="330" ClipToBounds="True">
-        <Image Source="avares://d2c-launcher/Assets/Images/splash/cm_lina.webp"
+        <Image RenderOptions.BitmapInterpolationMode="HighQuality" Source="avares://d2c-launcher/Assets/Images/splash/cm_lina.webp"
                Stretch="UniformToFill" HorizontalAlignment="Center" VerticalAlignment="Center"/>
         <Border Background="#48000000"/>
         <!-- Bottom caption gradient -->
@@ -197,7 +197,7 @@
 
       <!-- FEATURE 5 — mute -->
       <Panel MinHeight="330" ClipToBounds="True">
-        <Image Source="avares://d2c-launcher/Assets/Images/splash/mute.webp"
+        <Image RenderOptions.BitmapInterpolationMode="HighQuality" Source="avares://d2c-launcher/Assets/Images/splash/mute.webp"
                Stretch="UniformToFill" HorizontalAlignment="Center" VerticalAlignment="Center"/>
         <Border Background="#48000000"/>
         <!-- Bottom caption gradient -->
@@ -225,7 +225,7 @@
 
       <!-- FEATURE 6 — lobby -->
       <Panel MinHeight="330" ClipToBounds="True">
-        <Image Source="avares://d2c-launcher/Assets/Images/splash/lobby.webp"
+        <Image RenderOptions.BitmapInterpolationMode="HighQuality" Source="avares://d2c-launcher/Assets/Images/splash/lobby.webp"
                Stretch="UniformToFill" HorizontalAlignment="Center" VerticalAlignment="Center"/>
         <Border Background="#48000000"/>
         <!-- Bottom caption gradient -->
@@ -265,7 +265,7 @@
                   Padding="28,11" CornerRadius="2" Cursor="Hand"
                   HorizontalAlignment="Center">
             <StackPanel Orientation="Horizontal" Spacing="10">
-              <Image Source="avares://d2c-launcher/Assets/Images/telegram.png"
+              <Image RenderOptions.BitmapInterpolationMode="HighQuality" Source="avares://d2c-launcher/Assets/Images/telegram.png"
                      Width="15" Height="15" VerticalAlignment="Center"/>
               <TextBlock Text="{Binding StoreButtonText}"
                          FontSize="{DynamicResource FontSizeMD}" FontWeight="Bold"/>

--- a/Views/Components/StreamsPanel.axaml
+++ b/Views/Components/StreamsPanel.axaml
@@ -78,7 +78,7 @@
 
                         <!-- Thumbnail -->
                         <Border Grid.Row="0" Height="153" ClipToBounds="True" Background="#0a0f18">
-                          <Image asyncImageLoader:ImageLoader.Source="{Binding Preview}"
+                          <Image RenderOptions.BitmapInterpolationMode="HighQuality" asyncImageLoader:ImageLoader.Source="{Binding Preview}"
                                  Stretch="UniformToFill"/>
                         </Border>
 
@@ -104,7 +104,7 @@
                             <StackPanel Grid.Column="0" Orientation="Horizontal" Spacing="7">
                               <Border Width="20" Height="20" CornerRadius="10" ClipToBounds="True"
                                       Background="#1a2535">
-                                <Image asyncImageLoader:ImageLoader.Source="{Binding User.AvatarSmall}"
+                                <Image RenderOptions.BitmapInterpolationMode="HighQuality" asyncImageLoader:ImageLoader.Source="{Binding User.AvatarSmall}"
                                        Stretch="UniformToFill"/>
                               </Border>
                               <TextBlock Text="{Binding User.Name}"


### PR DESCRIPTION
## Summary

- Adds `RenderOptions.BitmapInterpolationMode="HighQuality"` to all 32 `<Image>` elements across 12 AXAML files
- Switches Skia from nearest-neighbour to bilinear/bicubic filtering for hero portraits, item icons, achievement images, social icons, etc.
- A global Style setter is not possible (Avalonia packs render options into a private struct with no exposed `AvaloniaProperty`), so applied per element

Closes #187